### PR TITLE
only update user after successful config call

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -66,6 +66,7 @@ ext {
     swagger_annotations_version = "2.1.11"
     junit_version = "4.13.2"
     jackson_version = "2.13.0"
+    jackson_kotlin_version = "2.13.0"
     mockito_core_version = "4.0.0"
 }
 
@@ -77,6 +78,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-jackson:$retrofit_version")
     implementation "io.swagger.core.v3:swagger-annotations:$swagger_annotations_version"
     implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${jackson_kotlin_version}")
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
@@ -6,7 +6,7 @@ import com.devcycle.sdk.android.model.*
 import com.devcycle.sdk.android.model.Event
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -15,7 +15,7 @@ import java.io.IOException
 internal class Request constructor(envKey: String) {
     private val api: DVCApi = DVCApiClient().initialize()
     private val eventApi: DVCEventsApi = DVCEventsApiClient().initialize(envKey)
-    private val objectMapper = ObjectMapper()
+    private val objectMapper = jacksonObjectMapper()
 
     private fun <T> getResponseHandler(callback: DVCCallback<T?>?) = object : Callback<T?> {
         override fun onResponse(

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DVCUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DVCUser.kt
@@ -3,7 +3,6 @@ package com.devcycle.sdk.android.model
 import com.fasterxml.jackson.annotation.JsonProperty
 
 class DVCUser private constructor(
-    var isAnonymous: Boolean,
     var userId: String? = null,
     var email: String? = null,
     var name: String? = null,
@@ -24,7 +23,6 @@ class DVCUser private constructor(
         private var appBuild: String? = null
         private var customData: Any? = null
         private var privateCustomData: Any? = null
-        private var isAnonymous = true
 
         @JsonProperty("user_id")
         fun withUserId(userId: String?): Builder {
@@ -72,14 +70,8 @@ class DVCUser private constructor(
             return this
         }
 
-        fun withIsAnonymous(isAnonymous: Boolean): Builder {
-            this.isAnonymous = isAnonymous
-            return this
-        }
-
         fun build(): DVCUser {
             return DVCUser(
-                isAnonymous,
                 userId,
                 email,
                 name,

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Event.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Event.kt
@@ -43,7 +43,7 @@ internal class Event internal constructor(
             return Event(
                 EventTypes.customEvent,
                 dvcEvent.type,
-                user.getUserId(),
+                user.userId,
                 featureVars ?: emptyMap(),
                 dvcEvent.target,
                 dvcEvent.date.time,
@@ -79,7 +79,7 @@ internal class Event internal constructor(
             return Event(
                 event.type,
                 null,
-                user.getUserId(),
+                user.userId,
                 featureVars ?: emptyMap(),
                 event.target,
                 event.date ?: Calendar.getInstance().time.time,

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
@@ -11,175 +11,61 @@ import java.util.*
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = User.Builder::class)
-internal class User private constructor(
-    userId: String?,
-    email: String?,
-    name: String?,
-    language: String?,
-    country: String?,
-    appVersion: String?,
-    appBuild: String?,
-    customData: Any?,
-    privateCustomData: Any?,
-    createdDate: Long,
-    platform: String,
-    platformVersion: String,
-    deviceModel: String,
-    sdkType: String,
-    sdkVersion: String,
-    isAnonymous: Boolean,
-    lastSeenDate: Long?
-) {
-    @JsonProperty("isAnonymous")
-    private val isAnonymous: Boolean
-
+internal data class User private constructor(
     @Schema(required = true, description = "Unique id to identify the user")
     @JsonProperty("user_id")
-    private val userId: String
-
+    val userId: String,
     @Schema(description = "User's email used to identify the user on the dashboard / target audiences")
-    @JsonProperty("email")
-    private var email: String?
-
+    val email: String?,
     @Schema(description = "User's name used to identify the user on the dashboard / target audiences")
-    @JsonProperty("name")
-    private var name: String?
-
+    val name: String?,
     @Schema(description = "User's language in ISO 639-1 format")
-    @JsonProperty("language")
-    private var language: String?
-
+    val language: String?,
     @Schema(description = "User's country in ISO 3166 alpha-2 format")
-    @JsonProperty("country")
-    private var country: String?
-
+    val country: String?,
     @Schema(description = "App Version of the running application")
-    @JsonProperty("appVersion")
-    private var appVersion: String?
-
+    val appVersion: String?,
     @Schema(description = "App Build number of the running application")
-    @JsonProperty("appBuild")
-    private var appBuild: String?
-
+    val appBuild: String?,
     @Schema(description = "User's custom data to target the user with, data will be logged to DevCycle for use in dashboard.")
-    @JsonProperty("customData")
-    private var customData: Any?
-
+    val customData: Any?,
     @Schema(description = "User's custom data to target the user with, data will not be logged to DevCycle only used for feature bucketing.")
-    @JsonProperty("privateCustomData")
-    private var privateCustomData: Any?
-
+    val privateCustomData: Any?,
     @Schema(description = "Date the user was created, Unix epoch timestamp format")
-    @JsonProperty("createdDate")
-    private val createdDate: Long
-
-    @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
-    @JsonProperty("lastSeenDate")
-    private var lastSeenDate: Long
-
+    val createdDate: Long,
     @Schema(description = "Platform the Client SDK is running on")
-    @JsonProperty("platform")
-    private val platform: String
-
+    val platform: String,
     @Schema(description = "Version of the platform the Client SDK is running on")
-    @JsonProperty("platformVersion")
-    private val platformVersion: String
-
+    val platformVersion: String,
     @Schema(description = "User's device model")
-    @JsonProperty("deviceModel")
-    private val deviceModel: String
-
+    val deviceModel: String,
     @Schema(description = "DevCycle SDK type")
-    @JsonProperty("sdkType")
-    private val sdkType: String
-
+    val sdkType: String,
     @Schema(description = "DevCycle SDK Version")
-    @JsonProperty("sdkVersion")
-    private val sdkVersion: String
-
-    fun getIsAnonymous(): Boolean {
-        return isAnonymous
-    }
-
-    fun getUserId(): String {
-        return userId
-    }
-
-    fun getEmail(): String? {
-        return email
-    }
-
-    fun getName(): String? {
-        return name
-    }
-
-    fun getLanguage(): String? {
-        return language
-    }
-
-    fun getCountry(): String? {
-        return country
-    }
-
-    fun getAppVersion(): String? {
-        return appVersion
-    }
-
-    fun getAppBuild(): String? {
-        return appBuild
-    }
-
-    fun getCustomData(): Any? {
-        return customData
-    }
-
-    fun getPrivateCustomData(): Any? {
-        return privateCustomData
-    }
-
-    fun getCreatedDate(): Long {
-        return createdDate
-    }
-
-    fun getLastSeenDate(): Long {
-        return lastSeenDate
-    }
-
-    fun getPlatform(): String {
-        return platform
-    }
-
-    fun getPlatformVersion(): String {
-        return platformVersion
-    }
-
-    fun getDeviceModel(): String {
-        return deviceModel
-    }
-
-    fun getSdkType(): String {
-        return sdkType
-    }
-
-    fun getSdkVersion(): String {
-        return sdkVersion
-    }
+    val sdkVersion: String,
+    @JsonProperty("isAnonymous")
+    val isAnonymous: Boolean,
+    @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
+    val lastSeenDate: Long?
+) {
 
     @Throws(IllegalArgumentException::class)
     internal fun updateUser(user: DVCUser): User {
         if (this.userId != user.userId) {
             throw IllegalArgumentException("Cannot update a user with a different userId")
         }
-        email = user.email
-        name = user.name
-        language = user.language
-        country = user.country
-        appVersion = user.appVersion
-        appBuild = user.appBuild
-        customData = user.customData
-        privateCustomData = user.privateCustomData
-        lastSeenDate = Calendar.getInstance().time.time
-        return this;
+
+        return this.copy(
+            email = user.email,
+            name = user.name,
+            language = user.language,
+            country = user.country,
+            appVersion = user.appVersion,
+            appBuild = user.appBuild,
+            customData = user.customData,
+            privateCustomData = user.privateCustomData,
+            lastSeenDate = Calendar.getInstance().time.time
+        )
     }
 
     @JsonPOJOBuilder
@@ -193,7 +79,6 @@ internal class User private constructor(
         private var appBuild: String? = null
         private var customData: Any? = null
         private var privateCustomData: Any? = null
-        private var isAnonymous = true
         private var createdDate = Calendar.getInstance().time.time
         private var platform = "Android"
         private var platformVersion = Build.VERSION.RELEASE
@@ -248,11 +133,6 @@ internal class User private constructor(
             return this
         }
 
-        fun withIsAnonymous(isAnonymous: Boolean): Builder {
-            this.isAnonymous = isAnonymous
-            return this
-        }
-
         private fun withCreatedDate(createdDate: Long): Builder {
             this.createdDate = createdDate
             return this
@@ -289,7 +169,6 @@ internal class User private constructor(
         }
 
         internal fun withUserParam(user: DVCUser): Builder {
-            this.isAnonymous = user.isAnonymous
             this.userId = user.userId
             this.email = user.email
             this.name = user.name
@@ -303,8 +182,9 @@ internal class User private constructor(
         }
 
         fun build(): User {
+            val isAnonymous = userId == null
             return User(
-                userId,
+                if (isAnonymous) UUID.randomUUID().toString() else userId!!,
                 email,
                 name,
                 language,
@@ -320,7 +200,7 @@ internal class User private constructor(
                 sdkType,
                 sdkVersion,
                 isAnonymous,
-                lastSeenDate
+                lastSeenDate ?: Calendar.getInstance().time.time
             )
         }
 
@@ -333,25 +213,5 @@ internal class User private constructor(
         fun builder(): Builder {
             return Builder()
         }
-    }
-
-    init {
-        this.userId = if (isAnonymous && userId == "") UUID.randomUUID().toString() else userId!!
-        this.isAnonymous = isAnonymous
-        this.email = email
-        this.name = name
-        this.language = language
-        this.country = country
-        this.appVersion = appVersion
-        this.appBuild = appBuild
-        this.customData = customData
-        this.privateCustomData = privateCustomData
-        this.createdDate = createdDate
-        this.platform = platform
-        this.platformVersion = platformVersion
-        this.deviceModel = deviceModel
-        this.sdkType = sdkType
-        this.sdkVersion = sdkVersion
-        this.lastSeenDate = lastSeenDate ?: Calendar.getInstance().time.time
     }
 }


### PR DESCRIPTION
- only update local user data after successful config re-fetch when calling identifyUser or resetUser
- convert User class to data class to get access to `copy` method
- add Jackson kotlin module to support serializing data classes
- automatically set isAnonymous to false when user_id is set, do not expose it in the builders
- always reset user when calling resetUser even if user is already anonymous