### PR TITLE
Android EdgeDB

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -1,6 +1,7 @@
 package com.devcycle.sdk.android.api
 
 import android.content.Context
+import com.devcycle.sdk.android.exception.DVCRequestException
 import com.devcycle.sdk.android.listener.BucketedUserConfigListener
 import com.devcycle.sdk.android.model.*
 import com.devcycle.sdk.android.util.DVCSharedPrefs
@@ -310,14 +311,18 @@ class DVCClient private constructor(
 
         if (checkIfEdgeDBEnabled(config!!, enableEdgeDB)) {
             if (!user.isAnonymous) {
-                request.saveEntity(user)
+                try {
+                    request.saveEntity(user)
+                } catch (exception: DVCRequestException) {
+                    Timber.e("Error saving user entity for $user. Error: $exception")
+                }
             }
         }
     }
 
     private fun checkIfEdgeDBEnabled(config: BucketedUserConfig, enableEdgeDB: Boolean): Boolean {
-        if (config.project?.settings?.edgeDB?.enabled == true) {
-            return !!enableEdgeDB
+        return if (config.project?.settings?.edgeDB?.enabled == true) {
+            enableEdgeDB
         } else {
             Timber.d("EdgeDB is not enabled for this project. Only using local user data.")
             return false

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApi.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApi.kt
@@ -1,0 +1,15 @@
+package com.devcycle.sdk.android.api
+
+import com.devcycle.sdk.android.model.DVCResponse
+import com.devcycle.sdk.android.model.User
+import retrofit2.Response
+import retrofit2.http.*
+
+internal interface DVCEdgeDBApi {
+    @Headers("Content-Type:application/json")
+    @PATCH("/v1/edgeDB/{id}")
+    suspend fun saveEntity(
+        @Path("id") id: String?,
+        @Body userBody: User
+    ): Response<DVCResponse>
+}

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
@@ -1,0 +1,27 @@
+package com.devcycle.sdk.android.api
+
+import com.devcycle.sdk.android.interceptor.AuthorizationHeaderInterceptor
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+
+internal class DVCEdgeDBApiClient {
+    private val okBuilder: OkHttpClient.Builder = OkHttpClient.Builder()
+    private val objectMapper = jacksonObjectMapper()
+    private val adapterBuilder: Retrofit.Builder = Retrofit.Builder()
+        .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+
+    fun initialize(envKey: String, baseUrl: String): DVCEdgeDBApi {
+        okBuilder.addInterceptor(AuthorizationHeaderInterceptor(envKey))
+        return adapterBuilder
+            .baseUrl(baseUrl)
+            .client(okBuilder.build())
+            .build()
+            .create(DVCEdgeDBApi::class.java)
+    }
+
+    companion object {
+        internal const val BASE_URL = "https://sdk-api.devcycle.com/"
+    }
+}

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCOptions.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCOptions.kt
@@ -3,12 +3,14 @@ package com.devcycle.sdk.android.api
 class DVCOptions(
     private val environmentConfigPollingIntervalMs: Int,
     val flushEventsIntervalMs: Long,
-    private val disableEventLogging: Boolean
+    private val disableEventLogging: Boolean,
+    val enableEdgeDB: Boolean
 ) {
     class DVCOptionsBuilder internal constructor() {
         private var environmentConfigPollingIntervalMs = 0
         private var flushEventsIntervalMs = 0L
         private var disableEventLogging = false
+        private var enableEdgeDB = false
         fun environmentConfigPollingIntervalMs(environmentConfigPollingIntervalMs: Int): DVCOptionsBuilder {
             this.environmentConfigPollingIntervalMs = environmentConfigPollingIntervalMs
             return this
@@ -24,11 +26,17 @@ class DVCOptions(
             return this
         }
 
+        fun enableEdgeDB(enableEdgeDB: Boolean): DVCOptionsBuilder {
+            this.enableEdgeDB = enableEdgeDB
+            return this
+        }
+
         fun build(): DVCOptions {
             return DVCOptions(
                 environmentConfigPollingIntervalMs,
                 flushEventsIntervalMs,
-                disableEventLogging
+                disableEventLogging,
+                enableEdgeDB
             )
         }
     }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
@@ -1,0 +1,22 @@
+package com.devcycle.sdk.android.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+
+class EdgeDB {
+    /**
+     * Enabled flag, that is set by the Bucketed User Config -> Project Settings -> EdgeDB
+     * @return _id
+     */
+    @get:Schema(required = false, description = "flag that determines whether or not EdgeDB is enabled")
+    @JsonProperty("enabled")
+    var enabled: Boolean? = false
+
+    fun enabled(enabled: Boolean): EdgeDB {
+        this.enabled = enabled
+        return this
+    }
+}

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
@@ -38,6 +38,17 @@ class Project {
         description = "Unique key by Project, can be used in the SDK / API to reference by 'key' rather than _id."
     )
     var key: String? = null
+
+    /**
+     * Project Settings.
+     * @return settings
+     */
+    @get:Schema(
+        required = false,
+        description = "Settings by Project."
+    )
+    var settings: ProjectSettings? = null
+
     fun id(id: String?): Project {
         this.id = id
         return this
@@ -45,6 +56,11 @@ class Project {
 
     fun key(key: String?): Project {
         this.key = key
+        return this
+    }
+
+    fun settings(settings: ProjectSettings?): Project {
+        this.settings = settings
         return this
     }
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
@@ -1,0 +1,22 @@
+package com.devcycle.sdk.android.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+
+class ProjectSettings {
+    /**
+     * edgeDB Project Settings
+     * @return edgeDB
+     */
+    @get:Schema(required = false, description = "edgeDB Project Settings")
+    @JsonProperty("edgeDB")
+    var edgeDB: EdgeDB? = null
+
+    fun edgeDB(edgeDB: EdgeDB): ProjectSettings {
+        this.edgeDB = edgeDB
+        return this
+    }
+}


### PR DESCRIPTION
- add DVCOptions attribute of enableEdgeDB
- add EdgeDB saveEntity calls
- Add ProjectSettings class to Project so we can determine whether or not EdgeDB is enabled for a project
- Add unit tests & assertions to make sure `enableEdgeDB` is being sent correctly 