### PR TITLE
Fix to handle new top level fields on the Bucketed User Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This version of the DevCycle Android Client SDK supports a minimum Android API V
 The SDK can be installed into your Android project by adding the following to *build.gradle*:
 
 ```yaml
-implementation("com.devcycle:android-client-sdk:1.0.7")
+implementation("com.devcycle:android-client-sdk:1.0.8")
 ```
 
 Versions earlier than 1.0.6 are deprecated and contain either third party CVEs or issues that would prevent the DevCycle client from initializing correctly if the retrieved Config has had new properties added.

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.devcycle"
-version = "1.0.7"
+version = "1.0.8"
 
 android {
     compileSdk 31

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
@@ -15,11 +15,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+
 /**
  * ClientSDKAPIResponse
  */
 data class BucketedUserConfig internal constructor(
-    @JsonIgnoreProperties(ignoreUnknown = true)
     @get:Schema(required = true, description = "")
     val project: Project? = null,
     @get:Schema(required = true, description = "")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DVCUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DVCUser.kt
@@ -2,7 +2,6 @@ package com.devcycle.sdk.android.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.*
 
 class DVCUser private constructor(
     var userId: String? = null,


### PR DESCRIPTION
- move `@JsonIgnoreProperties(ignoreUnknown = true)` to apply to the entire BucketedUserConfig Model
- version bump to 1.0.8 to release