### PR TITLE
Dvc 4866 close method

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version")
     testImplementation("com.squareup.retrofit2:retrofit-mock:$retrofit_version")
     testImplementation("com.squareup.okhttp3:mockwebserver:$okhttp_version")
-
+    testImplementation 'org.json:json:20140107'
     testImplementation("androidx.arch.core:core-testing:$android_core_version")
 
     androidTestImplementation("androidx.test.ext:junit:$androidx_junit_version")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -192,6 +192,16 @@ class DVCClient private constructor(
         }
     }
 
+    fun close(callback: DVCCallback<String>? = null) {
+        coroutineScope.launch {
+            withContext(Dispatchers.IO) {
+                eventSource.close()
+            }
+            withContext(coroutineContext) {
+                eventQueue.close(callback)
+            }
+        }
+    }
     /**
      * Returns the Map of Features in the config
      */
@@ -246,6 +256,10 @@ class DVCClient private constructor(
      * [event] instance of an event object to submit
      */
     fun track(event: DVCEvent) {
+        if (eventQueue.isClosed.get()) {
+            Timber.d("DVC sdk has been closed, skipping call to track")
+            return
+        }
         eventQueue.queueEvent(Event.fromDVCEvent(event, user, config?.featureVariationMap))
     }
 

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -14,6 +14,7 @@ import com.devcycle.sdk.android.model.*
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
+import org.json.JSONObject
 import junit.framework.AssertionFailedError
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +26,8 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import org.json.JSONArray
+import org.junit.Assert
 import org.junit.jupiter.api.*
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
@@ -115,7 +118,7 @@ class DVCClientTests {
                 }
 
                 override fun onError(t: Throwable) {
-                    Assertions.assertEquals("Only 'mobile' keys are supported by this API", t.message)
+                    Assertions.assertEquals("Only 'mobile', 'dvc_mobile' keys are supported by this API", t.message)
                     calledBack = true
                     countDownLatch.countDown()
                 }
@@ -497,6 +500,73 @@ class DVCClientTests {
         }
     }
 
+    @Test
+    fun `close method will flush and then block events`() {
+        var calledBack = false
+        var error: Throwable? = null
+
+        val countDownLatch = CountDownLatch(1)
+
+        val config = generateConfig("activate-flag", "Flag activated!", Variable.TypeEnum.STRING)
+
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jacksonObjectMapper().writeValueAsString(config)))
+
+        mockWebServer.enqueue(MockResponse().setResponseCode(201).setBody("{\"message\": \"Success\"}"))
+
+        val flushInMs = 100L
+        val client = createClient("pretend-its-a-real-sdk-key", mockWebServer.url("/").toString(), flushInMs)
+
+        try {
+            client.onInitialized(object: DVCCallback<String> {
+                override fun onSuccess(result: String) {
+                    calledBack = true
+
+
+                    client.track(DVCEvent.builder()
+                        .withType("testEvent")
+                        .withMetaData(mapOf("test" to "value"))
+                        .build())
+
+                    client.close(object: DVCCallback<String>{
+                        override fun onSuccess(result: String) {
+                            client.track(DVCEvent.builder()
+                                .withType("newTestEvent")
+                                .withMetaData(mapOf("test2" to "value"))
+                                .build())
+                            val configRequest: RecordedRequest = mockWebServer.takeRequest()
+                            val eventsRequest: RecordedRequest = mockWebServer.takeRequest()
+
+                            val loggedEvents: String = eventsRequest.body.readUtf8()
+                            val eventsReqObj = JSONObject(loggedEvents)
+                            Mockito.spy(eventsReqObj)
+                            val events: JSONArray = eventsReqObj.get("events") as JSONArray
+                            Assertions.assertEquals(2, events.length())
+                            Assertions.assertEquals("userConfig", events.getJSONObject(0).get("type"))
+                            Assertions.assertEquals("testEvent", events.getJSONObject(1).get("customType"))
+                            countDownLatch.countDown()
+                        }
+                        override fun onError(t: Throwable) {
+                            error = t
+                            calledBack = true
+                            countDownLatch.countDown()
+                        }
+                    })
+                }
+
+                override fun onError(t: Throwable) {
+                    error = t
+                    calledBack = true
+                    countDownLatch.countDown()
+                }
+            })
+        } catch(t: Throwable) {
+            countDownLatch.countDown()
+        } finally {
+            countDownLatch.await(2000, TimeUnit.MILLISECONDS)
+            handleFinally(calledBack, error)
+        }
+    }
+
     private fun handleFinally(
         calledBack: Boolean,
         error: Throwable?,
@@ -533,8 +603,9 @@ class DVCClientTests {
     private fun generateConfig(key: String, value: String, type: Variable.TypeEnum): BucketedUserConfig {
         val variables: MutableMap<String, Variable<Any>> = HashMap()
         variables[key] = createNewVariable(key, value, type)
-
-        return BucketedUserConfig(variables = variables)
+        val sse = SSE()
+        sse.url = "https://www.bread.com"
+        return BucketedUserConfig(variables = variables, sse=sse)
     }
 
     private fun <T> createNewVariable(key: String, value: T, type: Variable.TypeEnum): Variable<Any> {

--- a/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
+++ b/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
@@ -1,8 +1,6 @@
 package com.devcycle.example
 
 import android.app.Application
-import android.os.SystemClock
-import android.util.Log
 import android.widget.Toast
 import com.devcycle.sdk.android.api.DVCCallback
 import com.devcycle.sdk.android.api.DVCClient
@@ -11,6 +9,7 @@ import com.devcycle.sdk.android.model.DVCUser
 import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.LogLevel
 import timber.log.Timber
+
 
 class KotlinApplication: Application() {
     var variable: Variable<String>? = null
@@ -32,11 +31,10 @@ class KotlinApplication: Application() {
 
         // Use your own demo variable here to see the value change from the defaultValue when the client is initialized
         variable = client.variable("<YOUR_VARIABLE_KEY>", "my string variable is not initialized yet");
-        Toast.makeText(applicationContext, variable?.value, Toast.LENGTH_SHORT).show()
 
         client.onInitialized(object : DVCCallback<String> {
             override fun onSuccess(result: String) {
-                //Toast.makeText(this@MainActivity, result, Toast.LENGTH_SHORT).show()
+//                Toast.makeText(this@MainActivity, result, Toast.LENGTH_SHORT).show()
                 client.flushEvents(object: DVCCallback<String> {
                     override fun onSuccess(result: String) {
                         Toast.makeText(applicationContext, result, Toast.LENGTH_SHORT).show()
@@ -53,8 +51,9 @@ class KotlinApplication: Application() {
                     .withMetaData(mapOf("test" to "value"))
                     .build())
 
+
                 // This toast onInitialized will show the value has changed
-                Toast.makeText(applicationContext, variable?.value, Toast.LENGTH_SHORT).show()
+                Toast.makeText(applicationContext, "$variable?.value", Toast.LENGTH_SHORT).show()
             }
 
             override fun onError(t: Throwable) {


### PR DESCRIPTION
Create a close method on the DVCClient which:
- closes the SSE connection
- Closes off the event queue and clears the scheduled flush jobs
- Flushes remaining events