### PR TITLE
feat: change callback signature for variable onUpdated to plain function

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Variable.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Variable.kt
@@ -189,7 +189,26 @@ class Variable<T> internal constructor() : PropertyChangeListener {
      *
      * [callback] returns the updated Variable inside callback.onSuccess(..)
      */
+    @Deprecated("Use the plain callback signature instead.")
     fun onUpdate(callback: DVCCallback<Variable<T>>) {
         this.callback = callback
+    }
+
+    /**
+     * To be notified when Variable.value changes register a callback by calling this method. The
+     * callback will replace any previously registered callback.
+     *
+     * [callback] called with the updated variable
+     */
+    fun onUpdate(callback: (Variable<T>) -> Unit) {
+        this.callback = object: DVCCallback<Variable<T>> {
+            override fun onSuccess(result: Variable<T>) {
+                callback(result)
+            }
+
+            override fun onError(t: Throwable) {
+                // no-op
+            }
+        }
     }
 }

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -355,6 +355,29 @@ class DVCClientTests {
     }
 
     @Test
+    fun `variable calls back when variable value changes using plain function`() {
+        val config = generateConfig("activate-flag", "Flag activated!", Variable.TypeEnum.STRING)
+
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(jacksonObjectMapper().writeValueAsString(config)))
+
+        val client = createClient("pretend-its-a-real-sdk-key", mockWebServer.url("/").toString())
+
+        try {
+            val variable = client.variable("activate-flag", "Not activated")
+            variable.onUpdate {
+                Assertions.assertEquals("Flag activated!", it.value)
+                calledBack = true
+                countDownLatch.countDown()
+            }
+        } catch(t: Throwable) {
+            countDownLatch.countDown()
+        } finally {
+            countDownLatch.await(2000, TimeUnit.MILLISECONDS)
+            handleFinally(calledBack, error)
+        }
+    }
+
+    @Test
     fun `events are flushed with delay`() {
         var calledBack = false
         var error: Throwable? = null

--- a/kotlin-example/src/main/java/com/devcycle/example/MainActivity.kt
+++ b/kotlin-example/src/main/java/com/devcycle/example/MainActivity.kt
@@ -28,15 +28,9 @@ class MainActivity : AppCompatActivity() {
             val variable = client.variable("realtime-demo", "default")
             setTextValue(variable.value)
 
-            variable.onUpdate(object: DVCCallback<Variable<String>> {
-                override fun onSuccess(result: Variable<String>) {
-                    setTextValue(variable.value)
-                }
-
-                override fun onError(t: Throwable) {
-                    // no-op
-                }
-            })
+            variable.onUpdate {
+                setTextValue(it.value)
+            }
         }
     }
 }


### PR DESCRIPTION
- add a better signature for the variable.onUpdate method which accepts a plain function rather than a DVCCallback object.
- mark the old signature as deprecated