### PR TITLE
 variable type fixes

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -257,8 +257,7 @@ class DVCClient private constructor(
      */
     @Synchronized
     fun <T: Any> variable(key: String, defaultValue: T): Variable<T> {
-        Variable.validateType(defaultValue)
-
+        Variable.getAndValidateType(defaultValue)
         val variable = this.getCachedVariable(key, defaultValue)
 
         val tmpConfig = config

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
@@ -56,7 +56,7 @@ internal class EventQueue constructor(
                 }
 
                 if (eventsToFlush.size == 0) {
-                    Timber.i("No events to flush.")
+                    Timber.d("No events to flush.")
                     return@withLock
                 }
 

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -651,13 +651,13 @@ class DVCClientTests {
         return BucketedUserConfig(variables = variables, sse=sse)
     }
 
-    private fun <T> createNewVariable(key: String, value: T, type: Variable.TypeEnum): Variable<Any> {
-        val variable: Variable<Any> = Variable()
-        variable.id = UUID.randomUUID().toString()
-        variable.type = type
-        variable.value = value
-        variable.key = key
-        return variable
+    private fun <T> createNewVariable(key: String, value: T, type: Variable.TypeEnum): Variable<T> {
+        return Variable(
+            id = UUID.randomUUID().toString(),
+            key = key,
+            value = value,
+            type = type
+        )
     }
 
     val requests = ConcurrentLinkedQueue<RecordedRequest>()


### PR DESCRIPTION
- make fields that are required to exist on the variable object non-optional
- fix initializing variables with the wrong type by using provided default values