### PR TITLE
Clear ANONYMOUS_USER_ID when resetting user

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -197,6 +197,7 @@ class DVCClient private constructor(
     @JvmOverloads
     @Synchronized
     fun resetUser(callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
+        val anonUserId = getAnonUserId()
         clearAnonUserId()
         val newUser: User = User.builder().withIsAnonymous(true).build()
         latestIdentifiedUser = newUser
@@ -216,6 +217,7 @@ class DVCClient private constructor(
                     fetchConfig(newUser)
                     config?.variables?.let { callback?.onSuccess(it) }
                 } catch (t: Throwable) {
+                    if (anonUserId !== null) setAnonUserId(anonUserId)
                     callback?.onError(t)
                 } finally {
                     handleQueuedConfigRequests()
@@ -381,6 +383,14 @@ class DVCClient private constructor(
 
     private fun saveUser() {
         dvcSharedPrefs.save(user, DVCSharedPrefs.UserKey)
+    }
+
+    private fun getAnonUserId(): String? {
+        return dvcSharedPrefs.getCache(DVCSharedPrefs.AnonUserIdKey)
+    }
+
+    private fun setAnonUserId(anonId: String) {
+        dvcSharedPrefs.save(anonId, DVCSharedPrefs.AnonUserIdKey)
     }
 
     private fun clearAnonUserId() {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -197,6 +197,7 @@ class DVCClient private constructor(
     @JvmOverloads
     @Synchronized
     fun resetUser(callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
+        clearAnonUserId()
         val newUser: User = User.builder().withIsAnonymous(true).build()
         latestIdentifiedUser = newUser
 

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -58,6 +58,7 @@ class DVCSharedPrefs(context: Context) {
         val jsonString = preferences.getString(key, null)
         if (jsonString == null) {
             Timber.e("%s could not be found in SharedPreferences file: %s", key, R.string.cached_data)
+            return null
         }
         try {
             return objectMapper.readValue(jsonString, prefs[key]) as T


### PR DESCRIPTION
- When resetting user, clear ANONYMOUS_USER_ID before building a new user object so that the new user has a different anonymous ID
- If reset fails, set anon user id back to previous value
- Update dvcSharedPrefs.getCache to return null if stored value is null