### PR TITLE
[DVC-5123] android store read anon user id on initialize

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -162,7 +162,7 @@ class DVCClient private constructor(
             this@DVCClient.user.copyUserAndUpdateFromDVCUser(user)
         } else {
             val anonId: String? = dvcSharedPrefs.getString(DVCSharedPrefs.AnonUserIdKey);
-            User.fromUserParam(user, context, anonId!!)
+            User.fromUserParam(user, context, anonId)
         }
         latestIdentifiedUser = updatedUser
 

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -161,7 +161,8 @@ class DVCClient private constructor(
         val updatedUser: User = if (this@DVCClient.user.userId == user.userId) {
             this@DVCClient.user.copyUserAndUpdateFromDVCUser(user)
         } else {
-            User.fromUserParam(user, context)
+            val anonId: String? = dvcSharedPrefs.getString(DVCSharedPrefs.AnonUserIdKey);
+            User.fromUserParam(user, context, anonId!!)
         }
         latestIdentifiedUser = updatedUser
 
@@ -197,7 +198,8 @@ class DVCClient private constructor(
     @JvmOverloads
     @Synchronized
     fun resetUser(callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
-        val anonUserId = getAnonUserId()
+        val anonUserId = dvcSharedPrefs!!.getString(DVCSharedPrefs.AnonUserIdKey)
+
         clearAnonUserId()
         val newUser: User = User.buildAnonymous()
         latestIdentifiedUser = newUser
@@ -385,14 +387,6 @@ class DVCClient private constructor(
         dvcSharedPrefs.save(user, DVCSharedPrefs.UserKey)
     }
 
-    private fun getAnonUserId(): String? {
-        return dvcSharedPrefs.getCache(DVCSharedPrefs.AnonUserIdKey)
-    }
-
-    private fun setAnonUserId(anonId: String) {
-        dvcSharedPrefs.save(anonId, DVCSharedPrefs.AnonUserIdKey)
-    }
-
     private fun clearAnonUserId() {
         dvcSharedPrefs.remove(DVCSharedPrefs.AnonUserIdKey)
     }
@@ -463,6 +457,8 @@ class DVCClient private constructor(
 
         private var dvcUser: DVCUser? = null
 
+        private var dvcSharedPrefs: DVCSharedPrefs? = null
+
         fun withContext(context: Context): DVCClientBuilder {
             this.context = context
             return this
@@ -514,7 +510,16 @@ class DVCClient private constructor(
                 Timber.plant(tree)
             }
 
-            this.user = User.fromUserParam(dvcUser!!, context!!)
+            dvcSharedPrefs = DVCSharedPrefs(context!!);
+
+            val anonId: String? = dvcSharedPrefs!!.getString(DVCSharedPrefs.AnonUserIdKey)
+
+            this.user = User.fromUserParam(dvcUser!!, context!!, anonId)
+
+            if(this.user!!.isAnonymous && this.user!!.userId !== anonId){
+                dvcSharedPrefs!!.saveString(this.user!!.userId, DVCSharedPrefs.AnonUserIdKey)
+            }
+
 
             return DVCClient(context!!, environmentKey!!, user!!, options, apiUrl, eventsUrl, customLifecycleHandler)
         }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -219,7 +219,7 @@ class DVCClient private constructor(
                     fetchConfig(newUser)
                     config?.variables?.let { callback?.onSuccess(it) }
                 } catch (t: Throwable) {
-                    if (anonUserId !== null) setAnonUserId(anonUserId)
+                    if (anonUserId !== null) dvcSharedPrefs!!.saveString(anonUserId, DVCSharedPrefs.AnonUserIdKey)
                     callback?.onError(t)
                 } finally {
                     handleQueuedConfigRequests()

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
@@ -84,7 +84,11 @@ internal data class User constructor(
             }
 
             val isAnonymous = user.isAnonymous ?: false
-            val userId = if (isAnonymous) if(anonUserId == null) UUID.randomUUID().toString() else anonUserId else user.userId
+            val userId = if (isAnonymous) {
+                anonUserId ?: UUID.randomUUID().toString()
+            } else {
+                user.userId
+            }
             val email = user.email
             val name = user.name
             val country = user.country

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/User.kt
@@ -76,7 +76,7 @@ internal data class User constructor(
             return User(userId, isAnonymous)
         }
 
-        @JvmSynthetic internal fun fromUserParam(user: DVCUser, context: Context): User {
+        @JvmSynthetic internal fun fromUserParam(user: DVCUser, context: Context, anonUserId: String?): User {
             val locale: Locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 context.resources.configuration.locales[0]
             } else {
@@ -84,7 +84,7 @@ internal data class User constructor(
             }
 
             val isAnonymous = user.isAnonymous ?: false
-            val userId = if (isAnonymous) UUID.randomUUID().toString() else user.userId
+            val userId = if (isAnonymous) if(anonUserId == null) UUID.randomUUID().toString() else anonUserId else user.userId
             val email = user.email
             val name = user.name
             val country = user.country

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -68,6 +68,25 @@ class DVCSharedPrefs(context: Context) {
         return null
     }
 
+    fun getString(key: String): String? {
+        val stringValue = preferences.getString(key,null)
+        if (stringValue == null) {
+            Timber.e("%s could not be found in SharedPreferences file: %s", key, R.string.cached_data)
+            return null
+        }
+        return stringValue
+    }
+
+    @Synchronized
+    fun saveString(value: String, key: String) {
+        try {
+            preferences.edit().putString(key, value).apply()
+            preferences.edit().commit()
+        } catch (e: JsonProcessingException) {
+            Timber.e(e, e.message)
+        }
+    }
+
     init {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
     }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -71,7 +71,7 @@ class DVCSharedPrefs(context: Context) {
     fun getString(key: String): String? {
         val stringValue = preferences.getString(key,null)
         if (stringValue == null) {
-            Timber.e("%s could not be found in SharedPreferences file: %s", key, R.string.cached_data)
+            Timber.i("%s could not be found in SharedPreferences file: %s", key, R.string.cached_data)
             return null
         }
         return stringValue


### PR DESCRIPTION
when initializing the DVCClient, compare and store anonymous user id to SharedPrefs to not create multiple anon users for same device. 