### PR TITLE
Fix configCacheTTL default

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCOptions.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCOptions.kt
@@ -4,14 +4,14 @@ class DVCOptions(
     val flushEventsIntervalMs: Long,
     private val disableEventLogging: Boolean,
     val enableEdgeDB: Boolean,
-    val configCacheTTL: Long,
+    val configCacheTTL: Long?,
     val disableConfigCache: Boolean
 ) {
     class DVCOptionsBuilder internal constructor() {
         private var flushEventsIntervalMs = 0L
         private var disableEventLogging = false
         private var enableEdgeDB = false
-        private var configCacheTTL= 0L
+        private var configCacheTTL: Long? = null
         private var disableConfigCache = false
 
         fun flushEventsIntervalMs(flushEventsIntervalMs: Long): DVCOptionsBuilder {


### PR DESCRIPTION
The configCacheTTL was defaulting to 0, so if a DVCOptions object was built without passing the configCacheTTL param it would disable the cache. 

Set configCacheTTL to null in the Options object, and let the DVCClient handle defaulting the value if it's not passed