### PR TITLE
Don't clear anonymous user ID when identifying a user

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -396,9 +396,6 @@ class DVCClient private constructor(
         dvcSharedPrefs.save(user, DVCSharedPrefs.UserKey)
         if (user.isAnonymous)
             dvcSharedPrefs.saveString(user.userId, DVCSharedPrefs.AnonUserIdKey)
-        else
-            dvcSharedPrefs.remove(DVCSharedPrefs.AnonUserIdKey)
-
     }
 
     private suspend fun fetchConfig(user: PopulatedUser, sse: Boolean? = false, lastModified: Long? = null) {


### PR DESCRIPTION
Previously whenever a non-anonymous user was idenified we would clear the cached anon ID. Instead we will only overwrite it when a new anon ID is generated (ie. via reset)