### PR TITLE
fix: parse variables from config as their own data class, attempt to fix onUpdate

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -166,7 +166,7 @@ class DVCClient private constructor(
      */
     @JvmOverloads
     @Synchronized
-    fun identifyUser(user: DVCUser, callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
+    fun identifyUser(user: DVCUser, callback: DVCCallback<Map<String, ReadOnlyVariable<Any>>>? = null) {
         flushEvents()
 
         val updatedUser: PopulatedUser = if (this@DVCClient.user.userId == user.userId) {
@@ -207,7 +207,7 @@ class DVCClient private constructor(
      */
     @JvmOverloads
     @Synchronized
-    fun resetUser(callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
+    fun resetUser(callback: DVCCallback<Map<String, ReadOnlyVariable<Any>>>? = null) {
         val newUser: PopulatedUser = PopulatedUser.buildAnonymous()
         latestIdentifiedUser = newUser
 
@@ -257,7 +257,7 @@ class DVCClient private constructor(
      * Returns the Map of Variables in the config
      */
     @Synchronized
-    fun allVariables(): Map<String, Variable<Any>>? {
+    fun allVariables(): Map<String, ReadOnlyVariable<Any>>? {
         return if (config == null) emptyMap() else config!!.variables
     }
 
@@ -291,7 +291,7 @@ class DVCClient private constructor(
     }
 
     private fun <T: Any> getCachedVariable(key: String, defaultValue: T): Variable<T> {
-        val variableByKey: Variable<Any>? = config?.variables?.get(key)
+        val variableByKey: ReadOnlyVariable<Any>? = config?.variables?.get(key)
         val variable: Variable<T>
 
         if (!variableInstanceMap.containsKey(key)) {
@@ -354,7 +354,7 @@ class DVCClient private constructor(
              */
             while (!configRequestQueue.isEmpty()) {
                 var latestUserAndCallback: UserAndCallback = configRequestQueue.remove()
-                val callbacks: MutableList<DVCCallback<Map<String, Variable<Any>>>> =
+                val callbacks: MutableList<DVCCallback<Map<String, ReadOnlyVariable<Any>>>> =
                     mutableListOf()
 
                 if (latestUserAndCallback.callback != null) {
@@ -420,7 +420,7 @@ class DVCClient private constructor(
         }
     }
 
-    private fun refetchConfig(sse: Boolean = false, lastModified: Long? = null, callback: DVCCallback<Map<String, Variable<Any>>>? = null) {
+    private fun refetchConfig(sse: Boolean = false, lastModified: Long? = null, callback: DVCCallback<Map<String, ReadOnlyVariable<Any>>>? = null) {
         if (isExecuting.get()) {
             configRequestQueue.add(UserAndCallback(latestIdentifiedUser, callback))
             Timber.d("Queued refetchConfig request")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/UserAndCallback.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/UserAndCallback.kt
@@ -1,11 +1,12 @@
 package com.devcycle.sdk.android.api
 
 import com.devcycle.sdk.android.model.PopulatedUser
+import com.devcycle.sdk.android.model.ReadOnlyVariable
 import com.devcycle.sdk.android.model.Variable
 
 internal class UserAndCallback internal constructor(
     val user: PopulatedUser,
-    val callback: DVCCallback<Map<String, Variable<Any>>>?
+    val callback: DVCCallback<Map<String, ReadOnlyVariable<Any>>>?
 ){
     val now: Long = System.currentTimeMillis()
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/DVCVariableException.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/DVCVariableException.kt
@@ -1,8 +1,9 @@
 package com.devcycle.sdk.android.exception
 
+import com.devcycle.sdk.android.model.ReadOnlyVariable
 import com.devcycle.sdk.android.model.Variable
 
-class DVCVariableException(message:String, currentVariable: Variable<Any>, updatedVariable: Variable<Any>): Exception(message) {
+class DVCVariableException(message:String, currentVariable: Variable<Any>, updatedVariable: ReadOnlyVariable<Any>): Exception(message) {
     val currentVariable = currentVariable
     val updatedVariable = updatedVariable
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
@@ -30,7 +30,7 @@ data class BucketedUserConfig internal constructor(
     @get:Schema(description = "Map of `Feature._id` to `Feature._variation` used for event logging.")
     val featureVariationMap: Map<String, String>? = null,
     @get:Schema(description = "Map of `Variable.key` to `Variable` values.")
-    val variables: Map<String, Variable<Any>>? = null,
+    val variables: Map<String, ReadOnlyVariable<Any>>? = null,
     @get:Schema(description = "Hashes `murmurhash.v3(variable.key + environment.apiKey)` of all known variable keys not contained in the `variables` object.")
     val knownVariableKeys: List<BigDecimal>? = null,
     @get:Schema(description = "Contains the SSE connection URL")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ReadOnlyVariable.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ReadOnlyVariable.kt
@@ -1,0 +1,14 @@
+package com.devcycle.sdk.android.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ReadOnlyVariable<T>(
+    @JsonProperty("_id")
+    val id: String,
+    val value: T,
+    val key: String,
+    val type: Variable.TypeEnum,
+    val evalReason: String?
+)

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -220,8 +220,8 @@ class DVCClientTests {
         try {
             client.onInitialized(object : DVCCallback<String> {
                 override fun onSuccess(result: String) {
-                    client.resetUser(object: DVCCallback<Map<String, Variable<Any>>> {
-                        override fun onSuccess(result: Map<String, Variable<Any>>) {
+                    client.resetUser(object: DVCCallback<Map<String, ReadOnlyVariable<Any>>> {
+                        override fun onSuccess(result: Map<String, ReadOnlyVariable<Any>>) {
                             Assertions.assertEquals("Flag activated!", result["activate-flag"]?.value.toString())
                         }
 
@@ -233,8 +233,8 @@ class DVCClientTests {
 
                     })
 
-                    client.identifyUser(DVCUser.builder().withUserId("new_userid").build(), object: DVCCallback<Map<String, Variable<Any>>> {
-                        override fun onSuccess(result: Map<String, Variable<Any>>) {
+                    client.identifyUser(DVCUser.builder().withUserId("new_userid").build(), object: DVCCallback<Map<String, ReadOnlyVariable<Any>>> {
+                        override fun onSuccess(result: Map<String, ReadOnlyVariable<Any>>) {
                             Assertions.assertEquals("Second!", result["wobble"]?.value.toString())
                             calledBack = true
                             countDownLatch.countDown()
@@ -283,8 +283,8 @@ class DVCClientTests {
 
         val i = AtomicInteger(0)
 
-        val callback = object: DVCCallback<Map<String, Variable<Any>>> {
-            override fun onSuccess(result: Map<String, Variable<Any>>) {
+        val callback = object: DVCCallback<Map<String, ReadOnlyVariable<Any>>> {
+            override fun onSuccess(result: Map<String, ReadOnlyVariable<Any>>) {
                 Assertions.assertEquals("Flag activated!", result["activate-flag"]?.value.toString())
 
                 if (i.get() == 0) {
@@ -461,8 +461,8 @@ class DVCClientTests {
 
         val client = createClient(user=DVCUser.builder().withIsAnonymous(true).build())
         val newUser = DVCUser.builder().withUserId("123").withIsAnonymous(false).build()
-        val callback = object: DVCCallback<Map<String, Variable<Any>>> {
-            override fun onSuccess(result: Map<String, Variable<Any>>) {
+        val callback = object: DVCCallback<Map<String, ReadOnlyVariable<Any>>> {
+            override fun onSuccess(result: Map<String, ReadOnlyVariable<Any>>) {
                 verify(editor, times(1))?.remove(eq("ANONYMOUS_USER_ID"))
             }
             override fun onError(t: Throwable) {}
@@ -477,8 +477,8 @@ class DVCClientTests {
         user.setAccessible(true)
 
         val client = createClient(user=DVCUser.builder().withIsAnonymous(true).build())
-        val callback = object: DVCCallback<Map<String, Variable<Any>>> {
-            override fun onSuccess(result: Map<String, Variable<Any>>) {
+        val callback = object: DVCCallback<Map<String, ReadOnlyVariable<Any>>> {
+            override fun onSuccess(result: Map<String, ReadOnlyVariable<Any>>) {
                 var anonUser: PopulatedUser = user.get(client) as PopulatedUser
                 verify(editor, times(1))?.putString(eq("ANONYMOUS_USER_ID"), eq(anonUser.userId))
             }
@@ -735,19 +735,20 @@ class DVCClientTests {
     }
 
     private fun generateConfig(key: String, value: String, type: Variable.TypeEnum): BucketedUserConfig {
-        val variables: MutableMap<String, Variable<Any>> = HashMap()
+        val variables: MutableMap<String, ReadOnlyVariable<Any>> = HashMap()
         variables[key] = createNewVariable(key, value, type)
         val sse = SSE()
         sse.url = "https://www.bread.com"
         return BucketedUserConfig(variables = variables, sse=sse)
     }
 
-    private fun <T> createNewVariable(key: String, value: T, type: Variable.TypeEnum): Variable<T> {
-        return Variable(
+    private fun <T> createNewVariable(key: String, value: T, type: Variable.TypeEnum): ReadOnlyVariable<T> {
+        return ReadOnlyVariable(
             id = UUID.randomUUID().toString(),
             key = key,
             value = value,
-            type = type
+            type = type,
+            evalReason = null
         )
     }
 


### PR DESCRIPTION
-Separate parsing of variables on the config into their own data class (ReadOnlyVariable)
-Update all the callbacks for identify etc. that were returning a map of full variable objects to just return "ReadOnlyVariables"
-Ensure defaultValue is always set on the regular `Variable` class by making it required
   - this should hopefully fix the bug with the onUpdate not always being fired when reverting to defaults.