### PR TITLE
DVC-6219 Rename occurrences of envKey and environmentKey with sdkKey

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCApi.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCApi.kt
@@ -9,7 +9,7 @@ import retrofit2.http.QueryMap
 interface DVCApi {
     @GET("/v1/mobileSDKConfig")
     suspend fun getConfigJson(
-        @Query("envKey") envKey: String,
+        @Query("sdkKey") sdkKey: String,
         @QueryMap params: Map<String, String>
     ): Response<BucketedUserConfig>
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
@@ -12,8 +12,8 @@ internal class DVCEdgeDBApiClient {
     private val adapterBuilder: Retrofit.Builder = Retrofit.Builder()
         .addConverterFactory(JacksonConverterFactory.create(objectMapper))
 
-    fun initialize(envKey: String, baseUrl: String): DVCEdgeDBApi {
-        okBuilder.addInterceptor(AuthorizationHeaderInterceptor(envKey))
+    fun initialize(sdkKey: String, baseUrl: String): DVCEdgeDBApi {
+        okBuilder.addInterceptor(AuthorizationHeaderInterceptor(sdkKey))
         return adapterBuilder
             .baseUrl(baseUrl)
             .client(okBuilder.build())

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEventsApiClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEventsApiClient.kt
@@ -12,8 +12,8 @@ internal class DVCEventsApiClient {
     private val adapterBuilder: Retrofit.Builder = Retrofit.Builder()
         .addConverterFactory(JacksonConverterFactory.create(objectMapper))
 
-    fun initialize(envKey: String, baseUrl: String): DVCEventsApi {
-        okBuilder.addInterceptor(AuthorizationHeaderInterceptor(envKey))
+    fun initialize(sdkKey: String, baseUrl: String): DVCEventsApi {
+        okBuilder.addInterceptor(AuthorizationHeaderInterceptor(sdkKey))
         return adapterBuilder
             .baseUrl(baseUrl)
             .client(okBuilder.build())

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
@@ -15,10 +15,10 @@ import retrofit2.Response
 import timber.log.Timber
 import java.io.IOException
 
-internal class Request constructor(envKey: String, apiBaseUrl: String, eventsBaseUrl: String) {
+internal class Request constructor(sdkKey: String, apiBaseUrl: String, eventsBaseUrl: String) {
     private val api: DVCApi = DVCApiClient().initialize(apiBaseUrl)
-    private val eventApi: DVCEventsApi = DVCEventsApiClient().initialize(envKey, eventsBaseUrl)
-    private val edgeDBApi: DVCEdgeDBApi = DVCEdgeDBApiClient().initialize(envKey, apiBaseUrl)
+    private val eventApi: DVCEventsApi = DVCEventsApiClient().initialize(sdkKey, eventsBaseUrl)
+    private val edgeDBApi: DVCEdgeDBApi = DVCEdgeDBApiClient().initialize(sdkKey, apiBaseUrl)
     private val objectMapper = jacksonObjectMapper()
     private val configMutex = Mutex()
 
@@ -46,7 +46,7 @@ internal class Request constructor(envKey: String, apiBaseUrl: String, eventsBas
     }
 
     suspend fun getConfigJson(
-        environmentKey: String,
+        sdkKey: String,
         user: PopulatedUser,
         enableEdgeDB: Boolean,
         sse: Boolean? = false,
@@ -79,7 +79,7 @@ internal class Request constructor(envKey: String, apiBaseUrl: String, eventsBas
             val maxDelay = 10000L
 
             flow {
-                val response = api.getConfigJson(environmentKey, map)
+                val response = api.getConfigJson(sdkKey, map)
                 emit(getResponseHandler(response))
             }
                 .flowOn(Dispatchers.Default)

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/interceptor/AuthorizationHeaderInterceptor.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/interceptor/AuthorizationHeaderInterceptor.kt
@@ -4,12 +4,12 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 
-class AuthorizationHeaderInterceptor(private val apiKey: String) : Interceptor {
+class AuthorizationHeaderInterceptor(private val sdkKey: String) : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         var request = chain.request()
         request = request.newBuilder()
-            .addHeader(AUTHORIZATION_HEADER, apiKey)
+            .addHeader(AUTHORIZATION_HEADER, sdkKey)
             .build()
         return chain.proceed(request)
     }

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -721,7 +721,7 @@ class DVCClientTests {
             .withContext(mockContext!!)
             .withHandler(mockHandler)
             .withUser(user ?: DVCUser.builder().withUserId("nic_test").build())
-            .withEnvironmentKey(sdkKey)
+            .withSDKKey(sdkKey)
             .withLogger(tree)
             .withApiUrl(mockUrl)
             .withOptions(

--- a/java-example/src/main/java/com/devcycle/javaexample/JavaApplication.java
+++ b/java-example/src/main/java/com/devcycle/javaexample/JavaApplication.java
@@ -30,7 +30,7 @@ public class JavaApplication extends Application {
                                 .withUserId("test_user")
                                 .build()
                 )
-                .withEnvironmentKey("<ADD-MOBILE-KEY-HERE>")
+                .withSDKKey("<YOUR_MOBILE_SDK_KEY>")
                 .withLogLevel(LogLevel.DEBUG)
                 .build();
 

--- a/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
+++ b/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
@@ -24,7 +24,7 @@ class KotlinApplication: Application() {
                     .withCustomData(mapOf("custom_value" to "test"))
                     .build()
             )
-            .withEnvironmentKey("<YOUR_MOBILE_SDK_KEY>")
+            .withSDKKey("<YOUR_MOBILE_SDK_KEY>")
             .withLogLevel(LogLevel.DEBUG)
             .withLogger(Timber.DebugTree())
             .build()


### PR DESCRIPTION
This is to be consistent across all our various SDKs we have aligned on `sdkKey` over `envKey` or `environmentKey`