### PR TITLE
fix: wrap close eventsource calls in coroutine in activity callbacks

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -103,16 +103,24 @@ class DVCClient private constructor(
     }
 
     private val onPauseApplication = fun () {
-        DVCLogger.d("Closing streaming event source connection")
-        eventSource?.close()
+        coroutineScope.launch {
+            withContext(Dispatchers.IO) {
+                DVCLogger.d("Closing streaming event source connection")
+                eventSource?.close()
+            }
+        }
     }
 
     private val onResumeApplication = fun () {
         if (eventSource?.state != ReadyState.OPEN) {
-            eventSource?.close()
-            DVCLogger.d("Restarting streaming event source connection")
-            initEventSource()
-            refetchConfig(false, null)
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    eventSource?.close()
+                    DVCLogger.d("Restarting streaming event source connection")
+                    initEventSource()
+                    refetchConfig(false, null)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Summary

Wrap `close` methods of `EventSource` in coroutines to prevent exceptions on network calls on the main thread