### PR TITLE
fix: on unknown exceptions, dont retry requests

### DIFF
--- a/android-client-sdk/src/main/AndroidManifest.xml
+++ b/android-client-sdk/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.devcycle.sdk.android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCApiClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCApiClient.kt
@@ -1,5 +1,7 @@
 package com.devcycle.sdk.android.api
 
+import android.content.Context
+import com.devcycle.sdk.android.interceptor.NetworkConnectionInterceptor
 import com.devcycle.sdk.android.util.JSONMapper
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -10,7 +12,8 @@ internal class DVCApiClient {
     private val adapterBuilder: Retrofit.Builder = Retrofit.Builder()
         .addConverterFactory(JacksonConverterFactory.create(JSONMapper.mapper))
 
-    fun initialize(baseUrl: String): DVCApi {
+    fun initialize(baseUrl: String, context: Context): DVCApi {
+        okBuilder.addInterceptor(NetworkConnectionInterceptor(context))
         return adapterBuilder
             .baseUrl(baseUrl)
             .client(okBuilder.build())

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCClient.kt
@@ -48,7 +48,7 @@ class DVCClient private constructor(
     private val defaultIntervalInMs: Long = 10000
     private val flushInMs: Long = options?.flushEventsIntervalMs ?: defaultIntervalInMs
     private val dvcSharedPrefs: DVCSharedPrefs = DVCSharedPrefs(context)
-    private val request: Request = Request(sdkKey, apiUrl, eventsUrl)
+    private val request: Request = Request(sdkKey, apiUrl, eventsUrl, context)
     private val observable: BucketedUserConfigListener = BucketedUserConfigListener()
     private val eventQueue: EventQueue = EventQueue(request, ::user, CoroutineScope(coroutineContext), flushInMs)
     private val enableEdgeDB: Boolean = options?.enableEdgeDB ?: false

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DVCEdgeDBApiClient.kt
@@ -1,6 +1,8 @@
 package com.devcycle.sdk.android.api
 
+import android.content.Context
 import com.devcycle.sdk.android.interceptor.AuthorizationHeaderInterceptor
+import com.devcycle.sdk.android.interceptor.NetworkConnectionInterceptor
 import com.devcycle.sdk.android.util.JSONMapper
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -11,8 +13,9 @@ internal class DVCEdgeDBApiClient {
     private val adapterBuilder: Retrofit.Builder = Retrofit.Builder()
         .addConverterFactory(JacksonConverterFactory.create(JSONMapper.mapper))
 
-    fun initialize(sdkKey: String, baseUrl: String): DVCEdgeDBApi {
+    fun initialize(sdkKey: String, baseUrl: String, context: Context): DVCEdgeDBApi {
         okBuilder.addInterceptor(AuthorizationHeaderInterceptor(sdkKey))
+        okBuilder.addNetworkInterceptor(NetworkConnectionInterceptor(context))
         return adapterBuilder
             .baseUrl(baseUrl)
             .client(okBuilder.build())

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.android.api
 
+import android.content.Context
 import com.devcycle.sdk.android.exception.DVCRequestException
 
 import com.devcycle.sdk.android.model.*
@@ -15,10 +16,10 @@ import retrofit2.Response
 import com.devcycle.sdk.android.util.DVCLogger
 import java.io.IOException
 
-internal class Request constructor(sdkKey: String, apiBaseUrl: String, eventsBaseUrl: String) {
-    private val api: DVCApi = DVCApiClient().initialize(apiBaseUrl)
+internal class Request constructor(sdkKey: String, apiBaseUrl: String, eventsBaseUrl: String, context: Context) {
+    private val api: DVCApi = DVCApiClient().initialize(apiBaseUrl, context)
     private val eventApi: DVCEventsApi = DVCEventsApiClient().initialize(sdkKey, eventsBaseUrl)
-    private val edgeDBApi: DVCEdgeDBApi = DVCEdgeDBApiClient().initialize(sdkKey, apiBaseUrl)
+    private val edgeDBApi: DVCEdgeDBApi = DVCEdgeDBApiClient().initialize(sdkKey, apiBaseUrl, context)
     private val configMutex = Mutex()
 
     private fun <T> getResponseHandler(response: Response<T>): T {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/NoNetworkException.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/NoNetworkException.kt
@@ -1,0 +1,5 @@
+package com.devcycle.sdk.android.exception
+
+import java.io.IOException
+
+class NoNetworkException(message: String?) : IOException(message) {  }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/interceptor/NetworkConnectionInterceptor.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/interceptor/NetworkConnectionInterceptor.kt
@@ -1,0 +1,42 @@
+package com.devcycle.sdk.android.interceptor
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.devcycle.sdk.android.exception.NoNetworkException
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class NetworkConnectionInterceptor(context: Context): Interceptor {
+    private val applicationContext: Context
+    init {
+        applicationContext = context
+    }
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var request = chain.request()
+        if (isNetworkAvailable()) {
+            throw NoNetworkException("No network connection is available")
+        }
+        return chain.proceed(request)
+    }
+
+    private fun isNetworkAvailable(): Boolean {
+        val connectivityManager =
+            applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+        if (connectivityManager is ConnectivityManager) {
+            val capabilities =
+                connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork) ?: return false
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+                return true
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                return true
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DVCClientTests.kt
@@ -271,6 +271,7 @@ class DVCClientTests {
         client.close()
     }
 
+    @ExperimentalCoroutinesApi
     @Test
     fun `ensure config requests are queued and executed later`() {
         val config = generateConfig("activate-flag", "Flag activated!", Variable.TypeEnum.STRING)

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/EventQueueTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/EventQueueTests.kt
@@ -1,10 +1,8 @@
 package com.devcycle.sdk.android.api
 
-import com.devcycle.sdk.android.helpers.TestDVCLogger
-import com.devcycle.sdk.android.model.DVCUser
+import android.content.Context
 import com.devcycle.sdk.android.model.Event
 import com.devcycle.sdk.android.model.PopulatedUser
-import com.devcycle.sdk.android.util.DVCLogger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -12,10 +10,14 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.mockito.Mock
 import org.mockito.Mockito
 import java.math.BigDecimal
 
+
 class EventQueueTests {
+
+    private val mockContext: Context = Mockito.mock(Context::class.java)
 
     @DelicateCoroutinesApi
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
@@ -37,7 +39,7 @@ class EventQueueTests {
 
     @Test
     fun `events are aggregated correctly`() {
-        val request = Request("some-key", "http://fake.com", "http://fake.com")
+        val request = Request("some-key", "http://fake.com", "http://fake.com", mockContext)
         val user = PopulatedUser("test")
         val eventQueue = EventQueue(request, { user }, CoroutineScope(Dispatchers.Default), 10000)
 


### PR DESCRIPTION
# Changes

- on unknown exceptions, don't retry the request (e.g. `UnknownHostException` when no internet connection)
- add interceptor to okhttp builder to throw an error immediately if the device is not connected to the internet