### PR TITLE
Upgrade to gradle 8.0.2, fix proguard rules for r8

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 18
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run build with Gradle Wrapper

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -9,13 +9,11 @@ group = "com.devcycle"
 version = "1.7.0"
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
-        versionCode 1
-        versionName version
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testBuildType "minified"
@@ -24,7 +22,12 @@ android {
 
         //Will create field in buildconfig.java for use in code. 
         buildConfigField 'String', 'VERSION_NAME', "\"$versionName\""
+    }
 
+        namespace 'com.devcycle'
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.devcycle"
-version = "1.7.0"
+version = "1.7.1"
 
 android {
     compileSdk 33
@@ -21,7 +21,7 @@ android {
         consumerProguardFiles("proguard-rules.pro")
 
         //Will create field in buildconfig.java for use in code. 
-        buildConfigField 'String', 'VERSION_NAME', "\"$versionName\""
+        buildConfigField 'String', 'VERSION_NAME', "\"$version\""
     }
 
         namespace 'com.devcycle'

--- a/android-client-sdk/proguard-rules.pro
+++ b/android-client-sdk/proguard-rules.pro
@@ -43,6 +43,8 @@
 -keep,allowobfuscation,allowshrinking class okhttp3.RequestBody
 -keep,allowobfuscation,allowshrinking class okhttp3.ResponseBody
 
+
+# IMPORTANT: This ensures R8 Will not strip our JSONMapper and Coroutine classes
 -keep,allowobfuscation,allowshrinking class com.devcycle.sdk.android.util.**
 
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/android-client-sdk/proguard-rules.pro
+++ b/android-client-sdk/proguard-rules.pro
@@ -19,5 +19,63 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# TODO: Update all retrofit rules when retrofit 5 is released.
+
 -keep class kotlin.Metadata { *; }
 -keep class com.devcycle.sdk.android.model.** { *; }
+-keep class java.beans.Transient.** {*;}
+-keep class java.beans.ConstructorProperties.** {*;}
+-keep class java.nio.file.Path.** {*;}
+-keepnames class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.core.type.TypeReference
+-dontwarn com.fasterxml.jackson.databind.**
+-dontwarn javax.annotation.**
+-dontwarn kotlin.Unit
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# Ignore annotation used for build tooling.
+#-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class okhttp3.RequestBody
+-keep,allowobfuscation,allowshrinking class okhttp3.ResponseBody
+
+-keep,allowobfuscation,allowshrinking class com.devcycle.sdk.android.util.**
+
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep inherited services.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>

--- a/android-client-sdk/proguard-rules.pro
+++ b/android-client-sdk/proguard-rules.pro
@@ -35,6 +35,16 @@
 -dontwarn retrofit2.KotlinExtensions
 -dontwarn retrofit2.KotlinExtensions$*
 
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE
+
 # Ignore annotation used for build tooling.
 #-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
@@ -45,7 +55,7 @@
 
 
 # IMPORTANT: This ensures R8 Will not strip our JSONMapper and Coroutine classes
--keep,allowobfuscation,allowshrinking class com.devcycle.sdk.android.util.**
+-keep,allowobfuscation,allowshrinking class com.devcycle.sdk.android.**
 
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 

--- a/android-client-sdk/src/main/AndroidManifest.xml
+++ b/android-client-sdk/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.devcycle.sdk.android">
+   >
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
@@ -4,13 +4,13 @@ package com.devcycle.sdk.android.model
 import android.content.Context
 import com.fasterxml.jackson.annotation.JsonProperty
 import android.os.Build
-import com.devcycle.sdk.android.BuildConfig
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 import android.content.pm.PackageInfo
+import com.devcycle.BuildConfig
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import kotlin.IllegalArgumentException
 
@@ -48,7 +48,7 @@ internal data class PopulatedUser constructor(
     @Schema(description = "DevCycle SDK type")
     val sdkType: String = "mobile",
     @Schema(description = "DevCycle SDK Version")
-    val sdkVersion: String = BuildConfig.VERSION_NAME,
+    val sdkVersion: String? = "1.5.0-victest",
     @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
     val lastSeenDate: Long? = Calendar.getInstance().time.time,
 ) {
@@ -101,6 +101,7 @@ internal data class PopulatedUser constructor(
             val packageInfo: PackageInfo = packageManager.getPackageInfo(context.packageName, 0)
         
             val appVersion = packageInfo.versionName
+            val versionName = packageInfo.versionName;
             val appBuild = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 packageInfo.longVersionCode
             } else {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
@@ -48,7 +48,7 @@ internal data class PopulatedUser constructor(
     @Schema(description = "DevCycle SDK type")
     val sdkType: String = "mobile",
     @Schema(description = "DevCycle SDK Version")
-    val sdkVersion: String? = BuildConfig.VERSION_NAME,
+    val sdkVersion: String = BuildConfig.VERSION_NAME,
     @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
     val lastSeenDate: Long? = Calendar.getInstance().time.time,
 ) {
@@ -101,7 +101,6 @@ internal data class PopulatedUser constructor(
             val packageInfo: PackageInfo = packageManager.getPackageInfo(context.packageName, 0)
         
             val appVersion = packageInfo.versionName
-            val versionName = packageInfo.versionName;
             val appBuild = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 packageInfo.longVersionCode
             } else {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/PopulatedUser.kt
@@ -48,7 +48,7 @@ internal data class PopulatedUser constructor(
     @Schema(description = "DevCycle SDK type")
     val sdkType: String = "mobile",
     @Schema(description = "DevCycle SDK Version")
-    val sdkVersion: String? = "1.5.0-victest",
+    val sdkVersion: String? = BuildConfig.VERSION_NAME,
     @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
     val lastSeenDate: Long? = Calendar.getInstance().time.time,
 ) {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -2,7 +2,7 @@ package com.devcycle.sdk.android.util
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.devcycle.sdk.android.R
+import com.devcycle.R
 import com.devcycle.sdk.android.model.BucketedUserConfig
 import com.devcycle.sdk.android.model.PopulatedUser
 import com.fasterxml.jackson.core.JsonProcessingException

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Jul 07 11:27:49 EDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java-example/build.gradle
+++ b/java-example/build.gradle
@@ -3,12 +3,14 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
+    namespace 'com.devcycle.javaexample'
+
 
     defaultConfig {
         applicationId "com.devcycle.javaexample"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/java-example/build.gradle
+++ b/java-example/build.gradle
@@ -26,6 +26,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        debug {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/java-example/gradle/wrapper/gradle-wrapper.properties
+++ b/java-example/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,6 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+
+## ENABLE THIS TO MAX OUT R8 MINIFICATION
+# android.enableR8.fullMode = true

--- a/java-example/gradle/wrapper/gradle-wrapper.properties
+++ b/java-example/gradle/wrapper/gradle-wrapper.properties
@@ -5,4 +5,4 @@ zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 
 ## ENABLE THIS TO MAX OUT R8 MINIFICATION
-# android.enableR8.fullMode = true
+android.enableR8.fullMode = true

--- a/java-example/src/main/AndroidManifest.xml
+++ b/java-example/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    >
 
     <application
         android:name="com.devcycle.javaexample.JavaApplication"

--- a/java-example/src/main/AndroidManifest.xml
+++ b/java-example/src/main/AndroidManifest.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.devcycle.javaexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:name=".JavaApplication"
+        android:name="com.devcycle.javaexample.JavaApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -11,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidClientSDK">
         <activity
-            android:name=".MainActivity"
+            android:name="com.devcycle.javaexample.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -23,9 +23,9 @@ android {
 
     buildTypes {
         debug {
-//            Enable these along with the app's full r8 mode in the gradle-wrapper.properties for max minification
-//            minifyEnabled true
-//            shrinkResources true
+            // Enable these along with the app's full r8 mode in the gradle-wrapper.properties for max minification
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
 

--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -4,12 +4,13 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
+    namespace 'com.devcycle.kotlinexample'
 
     defaultConfig {
         applicationId "com.devcycle.example"
-        minSdk 21
-        targetSdk 31
+        minSdk 24
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -21,8 +22,16 @@ android {
     }
 
     buildTypes {
+        debug {
+//            Enable these along with the app's full r8 mode in the gradle-wrapper.properties for max minification
+//            minifyEnabled true
+//            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -18,7 +18,7 @@ android {
     }
 
     buildFeatures {
-        buildConfig = false
+        buildConfig = true
     }
 
     buildTypes {

--- a/kotlin-example/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin-example/gradle/wrapper/gradle-wrapper.properties
@@ -5,5 +5,5 @@ zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 
 ## ENABLE THIS TO MAX OUT R8 MINIFICATION
-# android.enableR8.fullMode = true
+android.enableR8.fullMode = true
 

--- a/kotlin-example/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin-example/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,7 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+
+## ENABLE THIS TO MAX OUT R8 MINIFICATION
+# android.enableR8.fullMode = true
+

--- a/kotlin-example/src/main/AndroidManifest.xml
+++ b/kotlin-example/src/main/AndroidManifest.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.devcycle.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:name=".KotlinApplication"
+        android:name="com.devcycle.example.KotlinApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidClientSDK">
-        <activity android:name=".MainActivity"
+        <activity android:name="com.devcycle.example.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
+++ b/kotlin-example/src/main/java/com/devcycle/example/KotlinApplication.kt
@@ -50,9 +50,9 @@ class KotlinApplication: Application() {
 
                 client.track(
                     DVCEvent.builder()
-                    .withType("testEvent")
-                    .withMetaData(mapOf("test" to "value"))
-                    .build())
+                        .withType("testEvent")
+                        .withMetaData(mapOf("test" to "value"))
+                        .build())
 
 
                 // This toast onInitialized will show the value has changed

--- a/kotlin-example/src/main/java/com/devcycle/example/MainActivity.kt
+++ b/kotlin-example/src/main/java/com/devcycle/example/MainActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.devcycle.kotlinexample.R
 import com.devcycle.sdk.android.api.DVCCallback
 import com.devcycle.sdk.android.api.DVCClient
 import com.devcycle.sdk.android.model.DVCEvent


### PR DESCRIPTION
**Main problem**

The newest R8 strips a lot of stuff when its enabled.

I copied a ton of the details from here to add to our proguard consumer file:

https://github.com/square/retrofit/issues/3751

I also added a ton of protections around the jackson lib so that those types and files don't get stripped as well. 

Main item here too is making sure we `keep` the Android folder as it contains the coroutine schedule, objectmapper, and how we read configs locally and from the API

Other notes

* Force test apps to always run with R8 enabled so we catch these things earlier
* Update test apps to most recent version of gradle
* Update SDK to android 33 and newest Gradle 
* Update tests to handle new Android things which were failing