### PR TITLE
fix: allow async saving of SharedPreferences

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -57,7 +57,6 @@ internal class DVCSharedPrefs(context: Context) {
     fun saveString(value: String, key: String) {
         try {
             preferences.edit().putString(key, value).apply()
-            preferences.edit().commit()
         } catch (e: JsonProcessingException) {
             DevCycleLogger.e(e, e.message)
         }


### PR DESCRIPTION
- remove redundant `commit()` call 
  - `commit()` will apply changes to SharedPreferences synchronously which may cause slower performance