### PR TITLE
fix: wrapped throwable function in a try catch

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/eventsource/EventSource.java
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/eventsource/EventSource.java
@@ -277,7 +277,12 @@ public class EventSource implements Closeable {
 
   private void closeCurrentStream(ReadyState previousState) {
     if (previousState == ReadyState.OPEN) {
-      handler.onClosed();
+      try {
+        handler.onClosed();
+      } catch (Exception e) {
+        DevCycleLogger.w("Message handler threw an exception: " + e.toString());
+        handler.onError(e);
+      }
     }
 
     if (call != null) {


### PR DESCRIPTION
# Changes

- fixes onClosed throwing error up to the client when it should be catching it

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
