### PR TITLE
fix: crash in EventQueue from scheduleJob

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
@@ -26,7 +26,7 @@ internal class EventQueue constructor(
     internal val aggregateEventMap: HashMap<String, HashMap<String, Event>> = HashMap()
 
     private val scheduler = Scheduler(coroutineScope, flushInMs)
-    private lateinit var scheduleJob: Job
+    private var scheduleJob: Job? = null
     // mutex to control flushing events, ensuring only one operation at a time
     private val flushMutex = Mutex()
     // mutex to gate modifications to the aggregateEventMap
@@ -202,6 +202,6 @@ internal class EventQueue constructor(
         isClosed.set(true)
         closeCallback = callback
         flushEvents()
-        scheduleJob.cancelAndJoin()
+        scheduleJob?.cancelAndJoin()
     }
 }


### PR DESCRIPTION
change `scheduleJob` in `EventQueue` into a `nullable Job`, handle optional in `close()`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
