### PR TITLE
chore: add tests for extra properties successfully parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.1"
     }
 }
 task clean(type: Delete) {


### PR DESCRIPTION
- chore: adds some unit tests to ensure successful config parsing when extra properties are added at different levels (root vs nested of existing properties) on the Bucketed User Config