### PR TITLE
chore: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,6 @@
 name: Unit Test
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/android-client-sdk/security/code-scanning/1](https://github.com/DevCycleHQ/android-client-sdk/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it only needs to read the repository contents to check out the code and run tests. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
