### PR TITLE
chore: cleanup unnecessary JSON properties and annotations

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/BucketedUserConfig.kt
@@ -1,10 +1,7 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 
 /**
  * ClientSDKAPIResponse

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ConfigVariable.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ConfigVariable.kt
@@ -1,6 +1,5 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonParser
@@ -36,7 +35,6 @@ class VariableDeserializer : JsonDeserializer<BaseConfigVariable>() {
 }
 
 @JsonDeserialize(using = VariableDeserializer::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 abstract class BaseConfigVariable {
     abstract val id: String
     abstract val value: Any
@@ -46,7 +44,6 @@ abstract class BaseConfigVariable {
 }
 
 @JsonDeserialize(`as` = StringConfigVariable::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 class StringConfigVariable(
     @JsonProperty("_id")
     override val id: String,
@@ -57,7 +54,6 @@ class StringConfigVariable(
 ) : BaseConfigVariable()
 
 @JsonDeserialize(`as` = BooleanConfigVariable::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 class BooleanConfigVariable(
     @JsonProperty("_id")
     override val id: String,
@@ -68,7 +64,6 @@ class BooleanConfigVariable(
 ) : BaseConfigVariable()
 
 @JsonDeserialize(`as` = NumberConfigVariable::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 class NumberConfigVariable(
     @JsonProperty("_id")
     override val id: String,
@@ -79,7 +74,6 @@ class NumberConfigVariable(
 ) : BaseConfigVariable()
 
 @JsonDeserialize(`as` = JSONObjectConfigVariable::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 class JSONObjectConfigVariable(
     @JsonProperty("_id")
     override val id: String,
@@ -90,7 +84,6 @@ class JSONObjectConfigVariable(
 ) : BaseConfigVariable()
 
 @JsonDeserialize(`as` = JSONArrayConfigVariable::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 class JSONArrayConfigVariable(
     @JsonProperty("_id")
     override val id: String,

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DevCycleUser.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/DevCycleUser.kt
@@ -1,9 +1,8 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
-class DevCycleUser private constructor(
+data class DevCycleUser private constructor(
     private var _userId: String?,
     private var _isAnonymous: Boolean?,
     var email: String? = null,
@@ -28,8 +27,6 @@ class DevCycleUser private constructor(
     }
 
     class Builder internal constructor() {
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        
         private var userId: String? = null
         private var isAnonymous: Boolean? = null
         private var email: String? = null

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
@@ -3,7 +3,7 @@ package com.devcycle.sdk.android.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class EdgeDB {
+class EdgeDB {
     /**
      * Enabled flag, that is set by the Bucketed User Config -> Project Settings -> EdgeDB
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EdgeDB.kt
@@ -1,12 +1,9 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-
-class EdgeDB {
+data class EdgeDB {
     /**
      * Enabled flag, that is set by the Bucketed User Config -> Project Settings -> EdgeDB
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Environment.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Environment.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 /**
  * Environment
  */
-data class Environment {
+class Environment {
     /**
      * unique database id
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Environment.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Environment.kt
@@ -1,15 +1,12 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 
 /**
  * Environment
  */
-class Environment {
+data class Environment {
     /**
      * unique database id
      * @return _id
@@ -27,6 +24,7 @@ class Environment {
         description = "Unique key by Project, can be used in the SDK / API to reference by 'key' rather than _id."
     )
     var key: String? = null
+
     fun id(id: String?): Environment {
         this.id = id
         return this

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ErrorResponse.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ErrorResponse.kt
@@ -2,7 +2,6 @@ package com.devcycle.sdk.android.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import com.fasterxml.jackson.annotation.JsonFormat
-import java.util.*
 
 data class ErrorResponse (
     @Schema(required = true, description = "Error message")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ErrorResponse.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ErrorResponse.kt
@@ -2,9 +2,8 @@ package com.devcycle.sdk.android.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.util.*
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class ErrorResponse (
     @Schema(required = true, description = "Error message")
     @JsonFormat(with = [JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY])

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Feature.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Feature.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 /**
  * Feature
  */
-data class Feature {
+class Feature {
     /**
      * unique database id
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Feature.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Feature.kt
@@ -1,16 +1,13 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-
 /**
  * Feature
  */
-class Feature {
+data class Feature {
     /**
      * unique database id
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
@@ -1,15 +1,12 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 
 /**
  * Project
  */
-class Project {
+data class Project {
     /**
      * unique database id
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Project.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 /**
  * Project
  */
-data class Project {
+class Project {
     /**
      * unique database id
      * @return _id

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
@@ -1,12 +1,9 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-
-class ProjectSettings {
+data class ProjectSettings {
     /**
      * edgeDB Project Settings
      * @return edgeDB

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/ProjectSettings.kt
@@ -3,7 +3,7 @@ package com.devcycle.sdk.android.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class ProjectSettings {
+class ProjectSettings {
     /**
      * edgeDB Project Settings
      * @return edgeDB

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/SSE.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/SSE.kt
@@ -3,7 +3,7 @@ package com.devcycle.sdk.android.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class SSE {
+class SSE {
     /**
      * SSE connection URL, that is set by the Bucketed User Config -> SSE -> URL
      */

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/SSE.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/SSE.kt
@@ -1,12 +1,9 @@
 package com.devcycle.sdk.android.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-
-class SSE {
+data class SSE {
     /**
      * SSE connection URL, that is set by the Bucketed User Config -> SSE -> URL
      */

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Variable.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/Variable.kt
@@ -16,7 +16,6 @@ import com.devcycle.sdk.android.listener.BucketedUserConfigListener
 import com.devcycle.sdk.android.exception.DVCVariableException
 import com.devcycle.sdk.android.util.JSONMapper
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import kotlinx.coroutines.*
@@ -29,8 +28,6 @@ import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
 import java.lang.IllegalArgumentException
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-
 /**
  * Variable
  */
@@ -42,7 +39,7 @@ class Variable<T> internal constructor(
     @JsonProperty("_id")
     var id: String? = null,
     /**
-     * Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.
+     * Unique key by Project, can be used in the SDK / API to reference by 'key' rather than _id.
      * @return key
      */
     val key: String,


### PR DESCRIPTION
The JSON parsing library was audited to ensure unknown properties are ignored globally.

*   It was confirmed that `JSONMapper.kt` is configured with `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` set to `false`, which globally ignores unknown JSON properties during deserialization.
*   Consequently, all redundant `@JsonIgnoreProperties(ignoreUnknown = true)` annotations were removed from the following model classes:
    *   `BucketedUserConfig.kt`
    *   `Variable.kt`
    *   `ConfigVariable.kt` (6 instances across abstract and concrete classes)
    *   `SSE.kt`
    *   `ProjectSettings.kt`
    *   `Project.kt`
    *   `Feature.kt`
    *   `ErrorResponse.kt`
    *   `Environment.kt`
    *   `EdgeDB.kt`
    *   `DevCycleUser.kt`
*   Unused `import com.fasterxml.jackson.annotation.JsonIgnoreProperties` statements were also removed.
*   Other JSON annotations (`@JsonProperty`, `@JsonInclude`, `@JsonFormat`, `@JsonDeserialize`) were retained as they serve distinct, necessary purposes for serialization, formatting, and custom deserialization logic.