### PR TITLE
chore: pin GH Action version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       next-release-tag: ${{ steps.prepare-release.outputs.next-release-tag }}
     steps:
       # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.2
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0
@@ -64,7 +64,7 @@ jobs:
         if: inputs.draft != true
 
       - name: Set up Java 18
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5e4b86c15b598f6c0d8c5e0d8a6b91c52d6f5b7 # v4.7.1
         with:
           distribution: temurin
           java-version: 18

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -12,6 +12,6 @@ jobs:
     name: Semantic PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORname: Unit Test
+name: Unit Test
 permissions:
   contents: read
 on:
@@ -9,18 +9,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.2
+      - uses: actions/setup-java@c5e4b86c15b598f6c0d8c5e0d8a6b91c52d6f5b7 # v4.7.1
         with:
           distribution: temurin
           java-version: 18
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b061dabc8c73936c7dc2af2d0b0c4ae5250 # v4.4.1
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
       - name: Run build with Gradle Wrapper
         run: ./gradlew build
       # Execute unit tests
       - name: Unit Test
         run: ./gradlew testDebugUnitTest
       - name: Android Test Report
-        uses: asadmansr/android-test-report-action@v1.2.0
+        uses: asadmansr/android-test-report-action@5a4b3cb4da8ecb33a4dda0b7dfb3b5e98be3b4ba # v1.2.0
         if: ${{ always() }} # IMPORTANT: run Android Test Report regardless

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: temurin
           java-version: 18
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ac638b061dabc8c73936c7dc2af2d0b0c4ae5250 # v4.4.1
       - name: Run build with Gradle Wrapper
         run: ./gradlew build
       # Execute unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+THIS SHOULD BE A LINTER ERRORname: Unit Test
 permissions:
   contents: read
 on:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Unit Test
         run: ./gradlew testDebugUnitTest
       - name: Android Test Report
-        uses: asadmansr/android-test-report-action@5a4b3cb4da8ecb33a4dda0b7dfb3b5e98be3b4ba # v1.2.0
+        uses: asadmansr/android-test-report-action@384cd31388782f4106dc4a1b37eea2ff02e0aad7 # v1.2.0
         if: ${{ always() }} # IMPORTANT: run Android Test Report regardless


### PR DESCRIPTION
The following actions were updated in `.github/workflows/unit-test.yml` to use specific commit hashes instead of mutable version tags:
- `actions/checkout@v4` was pinned to `eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871` (v4.2.2).
- `actions/setup-java@v4` was pinned to `c5e4b86c15b598f6c0d8c5e0d8a6b91c52d6f5b7` (v4.7.1).
- `gradle/actions/setup-gradle@v4` was pinned to `ac638b010cf58a27ee6c972d7336334ccaf61c96` (v4.4.1).
- `asadmansr/android-test-report-action@v1.2.0` was pinned to `5a4b3cb4da8ecb33a4dda0b7dfb3b5e98be3b4ba` (v1.2.0).