### PR TITLE
Issue 262: OpenFeatureAPI usage precludes use of proprietary features

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -5,7 +5,6 @@ import com.devcycle.sdk.android.api.DevCycleCallback
 import com.devcycle.sdk.android.api.DevCycleClient
 import com.devcycle.sdk.android.api.DevCycleOptions
 import com.devcycle.sdk.android.model.BaseConfigVariable
-import com.devcycle.sdk.android.model.DevCycleEvent
 import com.devcycle.sdk.android.model.DevCycleUser
 import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.DevCycleLogger
@@ -14,7 +13,6 @@ import dev.openfeature.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONArray
 import org.json.JSONObject
-import java.math.BigDecimal
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -29,7 +27,11 @@ class DevCycleProvider(
     /**
      * The DevCycle client instance - created during initialization
      */
-    private var devCycleClient: DevCycleClient? = null
+    private var _devCycleClient: DevCycleClient? = null
+
+    val devCycleClient: DevCycleClient
+        get() = _devCycleClient
+            ?: error("DevCycleClient is not initialized. Call OpenFeatureAPI.setProvider() with this provider instance to initialize the DevCycleClient")
 
     /**
      * Helper function to create a ProviderEvaluation from a DevCycle variable
@@ -37,7 +39,7 @@ class DevCycleProvider(
     private fun <T> createProviderEvaluation(variable: Variable<*>, value: T): ProviderEvaluation<T> {
         val metadataBuilder = EvaluationMetadata.builder()
         var hasMetadata = false
-        
+
         // Add evaluation details and target ID if available
         variable.eval?.let { evalReason ->
             evalReason.details?.let { details ->
@@ -49,7 +51,7 @@ class DevCycleProvider(
                 hasMetadata = true
             }
         }
-        
+
         return ProviderEvaluation(
             value = value,
             variant = variable.key,
@@ -93,14 +95,14 @@ class DevCycleProvider(
                 .withContext(context)
                 .withSDKKey(sdkKey)
                 .withUser(user)
-            
+
             options?.let { clientBuilder.withOptions(it) }
-            
-            devCycleClient = clientBuilder.build()
+
+            _devCycleClient = clientBuilder.build()
 
             // Wait for DevCycle client to fully initialize
             suspendCancellableCoroutine<Unit> { continuation ->
-                devCycleClient!!.onInitialized(object : DevCycleCallback<String> {
+                _devCycleClient!!.onInitialized(object : DevCycleCallback<String> {
                     override fun onSuccess(result: String) {
                         DevCycleLogger.d("DevCycle OpenFeature provider initialized successfully")
                         continuation.resume(Unit)
@@ -124,8 +126,8 @@ class DevCycleProvider(
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        try {            
-            val client = devCycleClient
+        try {
+            val client = _devCycleClient
             if (client == null) {
                 DevCycleLogger.w(
                     "Context set before DevCycleProvider was fully initialized. " +
@@ -157,7 +159,7 @@ class DevCycleProvider(
     }
 
     override fun shutdown() {
-        devCycleClient?.close()
+        _devCycleClient?.close()
     }
 
     override fun getBooleanEvaluation(
@@ -165,7 +167,7 @@ class DevCycleProvider(
         defaultValue: Boolean,
         context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -175,7 +177,7 @@ class DevCycleProvider(
         defaultValue: Double,
         context: EvaluationContext?
     ): ProviderEvaluation<Double> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toDouble())
     }
@@ -185,7 +187,7 @@ class DevCycleProvider(
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toInt())
     }
@@ -195,7 +197,7 @@ class DevCycleProvider(
         defaultValue: Value,
         context: EvaluationContext?
     ): ProviderEvaluation<Value> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
 
         val (result, variable) = when {
             defaultValue is Value.Structure -> {
@@ -235,7 +237,7 @@ class DevCycleProvider(
         defaultValue: String,
         context: EvaluationContext?
     ): ProviderEvaluation<String> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -245,7 +247,7 @@ class DevCycleProvider(
         context: EvaluationContext?,
         details: TrackingEventDetails?
     ) {
-        val client = devCycleClient
+        val client = _devCycleClient
         if (client == null) {
             DevCycleLogger.w("Cannot track event '$trackingEventName': DevCycle client not initialized")
             return


### PR DESCRIPTION
https://github.com/DevCycleHQ/android-client-sdk/issues/262

While the OpenFeature API is of course meant to serve as a portable abstraction that can be used across numerous feature providers, customers may want to leverage some proprietary features of DevCycle where necessary while still abstracting the main functionality of checking feature variable values behind OpenFeature.

It would be useful to allow access to the underlying DevCycleClient from DevCycleProvider instances. For example, we need access to the allFeatures method for analytics purposes, but this is not available via OpenFeatureAPI.

I noticed that you expose the underlying DevCycle Client in the [Web Client](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/openfeature-web-provider/src/DevCycleProvider.ts#L45). This would be useful in the Android SDK as well.

This PR simply adds a getter for the underlying DevCycleClient

