### PR TITLE
feat: expose devcycleClient property from DevCycleProvider

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -27,11 +27,15 @@ class DevCycleProvider(
     /**
      * The DevCycle client instance - created during initialization
      */
-    private var _devCycleClient: DevCycleClient? = null
+    private var _devcycleClient: DevCycleClient? = null
 
-    val devCycleClient: DevCycleClient
-        get() = _devCycleClient
-            ?: error("DevCycleClient is not initialized. Call OpenFeatureAPI.setProvider() with this provider instance to initialize the DevCycleClient")
+    val devcycleClient: DevCycleClient
+        get() = _devcycleClient
+            ?: error(
+                "DevCycleClient is not initialized. " + 
+                "Call OpenFeatureAPI.setProvider() / OpenFeatureAPI.setProviderAndWait() " + 
+                "with this provider instance to initialize the DevCycleClient."
+            )
 
     /**
      * Helper function to create a ProviderEvaluation from a DevCycle variable
@@ -98,11 +102,11 @@ class DevCycleProvider(
 
             options?.let { clientBuilder.withOptions(it) }
 
-            _devCycleClient = clientBuilder.build()
+            _devcycleClient = clientBuilder.build()
 
             // Wait for DevCycle client to fully initialize
             suspendCancellableCoroutine<Unit> { continuation ->
-                _devCycleClient!!.onInitialized(object : DevCycleCallback<String> {
+                _devcycleClient!!.onInitialized(object : DevCycleCallback<String> {
                     override fun onSuccess(result: String) {
                         DevCycleLogger.d("DevCycle OpenFeature provider initialized successfully")
                         continuation.resume(Unit)
@@ -127,7 +131,7 @@ class DevCycleProvider(
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
         try {
-            val client = _devCycleClient
+            val client = _devcycleClient
             if (client == null) {
                 DevCycleLogger.w(
                     "Context set before DevCycleProvider was fully initialized. " +
@@ -159,7 +163,7 @@ class DevCycleProvider(
     }
 
     override fun shutdown() {
-        _devCycleClient?.close()
+        _devcycleClient?.close()
     }
 
     override fun getBooleanEvaluation(
@@ -167,7 +171,7 @@ class DevCycleProvider(
         defaultValue: Boolean,
         context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
-        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devcycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -177,7 +181,7 @@ class DevCycleProvider(
         defaultValue: Double,
         context: EvaluationContext?
     ): ProviderEvaluation<Double> {
-        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devcycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toDouble())
     }
@@ -187,7 +191,7 @@ class DevCycleProvider(
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
-        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devcycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toInt())
     }
@@ -197,7 +201,7 @@ class DevCycleProvider(
         defaultValue: Value,
         context: EvaluationContext?
     ): ProviderEvaluation<Value> {
-        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devcycleClient ?: return createDefaultProviderEvaluation(defaultValue)
 
         val (result, variable) = when {
             defaultValue is Value.Structure -> {
@@ -237,7 +241,7 @@ class DevCycleProvider(
         defaultValue: String,
         context: EvaluationContext?
     ): ProviderEvaluation<String> {
-        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devcycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -247,7 +251,7 @@ class DevCycleProvider(
         context: EvaluationContext?,
         details: TrackingEventDetails?
     ) {
-        val client = _devCycleClient
+        val client = _devcycleClient
         if (client == null) {
             DevCycleLogger.w("Cannot track event '$trackingEventName': DevCycle client not initialized")
             return

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -5,7 +5,6 @@ import com.devcycle.sdk.android.api.DevCycleCallback
 import com.devcycle.sdk.android.api.DevCycleClient
 import com.devcycle.sdk.android.api.DevCycleOptions
 import com.devcycle.sdk.android.model.BaseConfigVariable
-import com.devcycle.sdk.android.model.DevCycleEvent
 import com.devcycle.sdk.android.model.DevCycleUser
 import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.DevCycleLogger
@@ -14,7 +13,6 @@ import dev.openfeature.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONArray
 import org.json.JSONObject
-import java.math.BigDecimal
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -29,7 +27,11 @@ class DevCycleProvider(
     /**
      * The DevCycle client instance - created during initialization
      */
-    private var devCycleClient: DevCycleClient? = null
+    private var _devCycleClient: DevCycleClient? = null
+
+    val devCycleClient: DevCycleClient
+        get() = _devCycleClient
+            ?: error("DevCycleClient is not initialized. Call OpenFeatureAPI.setProvider() with this provider instance to initialize the DevCycleClient")
 
     /**
      * Helper function to create a ProviderEvaluation from a DevCycle variable
@@ -37,7 +39,7 @@ class DevCycleProvider(
     private fun <T> createProviderEvaluation(variable: Variable<*>, value: T): ProviderEvaluation<T> {
         val metadataBuilder = EvaluationMetadata.builder()
         var hasMetadata = false
-        
+
         // Add evaluation details and target ID if available
         variable.eval?.let { evalReason ->
             evalReason.details?.let { details ->
@@ -49,7 +51,7 @@ class DevCycleProvider(
                 hasMetadata = true
             }
         }
-        
+
         return ProviderEvaluation(
             value = value,
             variant = variable.key,
@@ -93,14 +95,14 @@ class DevCycleProvider(
                 .withContext(context)
                 .withSDKKey(sdkKey)
                 .withUser(user)
-            
+
             options?.let { clientBuilder.withOptions(it) }
-            
-            devCycleClient = clientBuilder.build()
+
+            _devCycleClient = clientBuilder.build()
 
             // Wait for DevCycle client to fully initialize
             suspendCancellableCoroutine<Unit> { continuation ->
-                devCycleClient!!.onInitialized(object : DevCycleCallback<String> {
+                _devCycleClient!!.onInitialized(object : DevCycleCallback<String> {
                     override fun onSuccess(result: String) {
                         DevCycleLogger.d("DevCycle OpenFeature provider initialized successfully")
                         continuation.resume(Unit)
@@ -124,8 +126,8 @@ class DevCycleProvider(
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        try {            
-            val client = devCycleClient
+        try {
+            val client = _devCycleClient
             if (client == null) {
                 DevCycleLogger.w(
                     "Context set before DevCycleProvider was fully initialized. " +
@@ -157,7 +159,7 @@ class DevCycleProvider(
     }
 
     override fun shutdown() {
-        devCycleClient?.close()
+        _devCycleClient?.close()
     }
 
     override fun getBooleanEvaluation(
@@ -165,7 +167,7 @@ class DevCycleProvider(
         defaultValue: Boolean,
         context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -175,7 +177,7 @@ class DevCycleProvider(
         defaultValue: Double,
         context: EvaluationContext?
     ): ProviderEvaluation<Double> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toDouble())
     }
@@ -185,7 +187,7 @@ class DevCycleProvider(
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value.toInt())
     }
@@ -195,7 +197,7 @@ class DevCycleProvider(
         defaultValue: Value,
         context: EvaluationContext?
     ): ProviderEvaluation<Value> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
 
         val (result, variable) = when {
             defaultValue is Value.Structure -> {
@@ -235,7 +237,7 @@ class DevCycleProvider(
         defaultValue: String,
         context: EvaluationContext?
     ): ProviderEvaluation<String> {
-        val client = devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
+        val client = _devCycleClient ?: return createDefaultProviderEvaluation(defaultValue)
         val variable = client.variable(key, defaultValue)
         return createProviderEvaluation(variable, variable.value)
     }
@@ -245,7 +247,7 @@ class DevCycleProvider(
         context: EvaluationContext?,
         details: TrackingEventDetails?
     ) {
-        val client = devCycleClient
+        val client = _devCycleClient
         if (client == null) {
             DevCycleLogger.w("Cannot track event '$trackingEventName': DevCycle client not initialized")
             return

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -72,8 +73,12 @@ class DevCycleProviderTest {
     }
 
     @Test
-    fun `accessing devCycleClient throws exception when client not initialized`() {
-        assertThrows(IllegalStateException::class.java) { provider.devCycleClient }
+    fun `accessing devcycleClient throws exception when client not initialized`() {
+        val exception = assertThrows(IllegalStateException::class.java) { provider.devcycleClient }
+        assertTrue(
+            exception.message?.contains("DevCycleClient is not initialized") == true,
+            "Exception message should contain 'DevCycleClient is not initialized'"
+        )
     }
 
     @Test
@@ -257,14 +262,14 @@ class DevCycleProviderTest {
     }
 
     @Test
-    fun `accessing devCycleClient returns devCycleClient when client is initialized`() {
+    fun `accessing devcycleClient returns devcycleClient when client is initialized`() {
         setupInitializedProvider()
-        assertEquals(mockDevCycleClient, provider.devCycleClient)
+        assertEquals(mockDevCycleClient, provider.devcycleClient)
     }
 
     private fun setupInitializedProvider() {
         // Make the devCycleClient available (simulate successful initialization)
-        val providerField = DevCycleProvider::class.java.getDeclaredField("_devCycleClient")
+        val providerField = DevCycleProvider::class.java.getDeclaredField("_devcycleClient")
         providerField.isAccessible = true
         providerField.set(provider, mockDevCycleClient)
     }


### PR DESCRIPTION
## Expose DevCycleClient from DevCycleProvider

Addresses the need to access proprietary DevCycle features while using the OpenFeature API, as outlined in #262.

**Based on the work from PR #263 by @nnoel-grubhub**

### Changes:
- **✨ New public property**: `devcycleClient` provides access to the underlying DevCycleClient instance
- **📝 Consistent naming**: Updated to camelCase convention (`devcycleClient`, `_devcycleClient`)
- **🧪 Enhanced testing**: Added comprehensive tests for property access and error cases

### Usage:
```kotlin
val provider = DevCycleProvider(sdkKey, context)
OpenFeatureAPI.setProviderAndWait(provider)

// Access proprietary features like allFeatures() for analytics
val allFeatures = provider.devcycleClient.allFeatures()
```

Closes #262