### PR TITLE
chore: upgrade openfeature kotlin sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The DevCycle Android SDK includes support for [OpenFeature](https://openfeature.
 
 ```kotlin
 import com.devcycle.sdk.android.openfeature.DevCycleProvider
-import dev.openfeature.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
 
 // Initialize the DevCycle provider
 val provider = DevCycleProvider(

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -138,8 +138,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_reflect_version")
     implementation("androidx.core:core-ktx:$androidx_version")
 
-    // OpenFeature Android SDK
-    implementation("dev.openfeature:android-sdk:0.4.1")
+    // OpenFeature Kotlin SDK
+    implementation("dev.openfeature:kotlin-sdk:0.6.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_version")

--- a/android-client-sdk/proguard-rules.pro
+++ b/android-client-sdk/proguard-rules.pro
@@ -118,5 +118,5 @@
 
 # OpenFeature integration classes
 -keep class com.devcycle.sdk.android.openfeature.** { *; }
--keep class dev.openfeature.sdk.** { *; }
--dontwarn dev.openfeature.sdk.**
+-keep class dev.openfeature.kotlin.sdk.** { *; }
+-dontwarn dev.openfeature.kotlin.sdk.**

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapper.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapper.kt
@@ -1,7 +1,6 @@
 package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.model.DevCycleUser
-import com.devcycle.sdk.android.util.DevCycleLogger
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.Value
 
@@ -15,7 +14,7 @@ object DevCycleContextMapper {
         var hasStandardAttributes = false
         var isAnonymousExplicitlySet = false
         
-        context.getTargetingKey()?.takeIf { it.isNotEmpty() }?.let {
+        context.getTargetingKey().takeIf { it.isNotEmpty() }?.let {
             userId = it
         } ?: run {
             context.getValue("user_id")?.takeIf { it is Value.String }?.asString()?.let {
@@ -176,14 +175,14 @@ object DevCycleContextMapper {
             is Value.Structure -> {
                 // Access structure directly
                 val structureMap = value.structure
-                structureMap?.mapValues { (_, v) -> 
-                    convertValueToAny(v) 
-                }?.filterValues { it != null }
+                structureMap.mapValues { (_, v) ->
+                    convertValueToAny(v)
+                }.filterValues { it != null }
             }
             is Value.List -> {
                 // Access list directly
                 val list = value.list
-                list?.mapNotNull { convertValueToAny(it) } ?: emptyList<Any>()
+                list.mapNotNull { convertValueToAny(it) }
             }
             else -> {
                 // Ensure the string representation is safe

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapper.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapper.kt
@@ -2,8 +2,8 @@ package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.model.DevCycleUser
 import com.devcycle.sdk.android.util.DevCycleLogger
-import dev.openfeature.sdk.EvaluationContext
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.Value
 
 object DevCycleContextMapper {
     

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapper.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapper.kt
@@ -2,8 +2,8 @@ package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.model.DevCycleEvent
 import com.devcycle.sdk.android.util.DevCycleLogger
-import dev.openfeature.sdk.TrackingEventDetails
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.Value
 import java.math.BigDecimal
 
 object DevCycleEventMapper {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapper.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapper.kt
@@ -1,7 +1,6 @@
 package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.model.DevCycleEvent
-import com.devcycle.sdk.android.util.DevCycleLogger
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import java.math.BigDecimal
@@ -55,14 +54,14 @@ object DevCycleEventMapper {
             is Value.Structure -> {
                 // Recursively unwrap nested structure
                 val structureMap = value.structure
-                structureMap?.mapValues { (_, v) -> 
+                structureMap.mapValues { (_, v) ->
                     unwrapValue(v) 
-                }?.filterValues { it != null }
+                }.filterValues { it != null }
             }
             is Value.List -> {
                 // Recursively unwrap nested list
                 val list = value.list
-                list?.mapNotNull { unwrapValue(it) }
+                list.mapNotNull { unwrapValue(it) }
             }
             else -> null
         }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -8,8 +8,8 @@ import com.devcycle.sdk.android.model.BaseConfigVariable
 import com.devcycle.sdk.android.model.DevCycleUser
 import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.DevCycleLogger
-import dev.openfeature.sdk.*
-import dev.openfeature.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.*
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONArray
 import org.json.JSONObject

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProviderMetadata.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProviderMetadata.kt
@@ -1,6 +1,6 @@
 package com.devcycle.sdk.android.openfeature
 
-import dev.openfeature.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderMetadata
 
 class DevCycleProviderMetadata(
     override val name: String = "DevCycle"

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/JsonValueConverter.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/JsonValueConverter.kt
@@ -1,6 +1,6 @@
 package com.devcycle.sdk.android.openfeature
 
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.Value
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapperTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleContextMapperTest.kt
@@ -2,8 +2,8 @@ package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.util.JSONMapper
 import com.fasterxml.jackson.core.type.TypeReference
-import dev.openfeature.sdk.ImmutableContext
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.Value
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapperTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleEventMapperTest.kt
@@ -2,9 +2,9 @@ package com.devcycle.sdk.android.openfeature
 
 import com.devcycle.sdk.android.util.JSONMapper
 import com.fasterxml.jackson.core.type.TypeReference
-import dev.openfeature.sdk.ImmutableStructure
-import dev.openfeature.sdk.TrackingEventDetails
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.ImmutableStructure
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.Value
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import java.math.BigDecimal

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
@@ -6,10 +6,10 @@ import com.devcycle.sdk.android.api.DevCycleClient
 import com.devcycle.sdk.android.model.BaseConfigVariable
 import com.devcycle.sdk.android.model.EvalReason
 import com.devcycle.sdk.android.model.Variable
-import dev.openfeature.sdk.EvaluationMetadata
-import dev.openfeature.sdk.ImmutableContext
-import dev.openfeature.sdk.TrackingEventDetails
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.EvaluationMetadata
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.Value
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/JsonValueConverterTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/JsonValueConverterTest.kt
@@ -1,6 +1,6 @@
 package com.devcycle.sdk.android.openfeature
 
-import dev.openfeature.sdk.Value
+import dev.openfeature.kotlin.sdk.Value
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.jupiter.api.Test

--- a/openfeature-example/README.md
+++ b/openfeature-example/README.md
@@ -82,5 +82,5 @@ client.track(
 
 This example uses:
 - DevCycle Android SDK (via project dependency)
-- OpenFeature Android SDK (0.4.1)
+- OpenFeature Kotlin SDK (0.6.2)
 - Standard Android libraries 

--- a/openfeature-example/build.gradle
+++ b/openfeature-example/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation(project(":android-client-sdk"))
-    implementation 'dev.openfeature:android-sdk:0.4.1'
+    implementation 'dev.openfeature:kotlin-sdk:0.6.2'
 }
 
 task wrapper(type: Wrapper){

--- a/openfeature-example/src/main/java/com/devcycle/example/OpenFeatureActivity.kt
+++ b/openfeature-example/src/main/java/com/devcycle/example/OpenFeatureActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
 import com.devcycle.openfeatureexample.R
-import dev.openfeature.sdk.*
+import dev.openfeature.kotlin.sdk.*
 
 class OpenFeatureActivity : AppCompatActivity() {
 

--- a/openfeature-example/src/main/java/com/devcycle/example/OpenFeatureApplication.kt
+++ b/openfeature-example/src/main/java/com/devcycle/example/OpenFeatureApplication.kt
@@ -5,7 +5,7 @@ import android.widget.Toast
 import com.devcycle.sdk.android.api.DevCycleOptions
 import com.devcycle.sdk.android.openfeature.DevCycleProvider
 import com.devcycle.sdk.android.util.LogLevel
-import dev.openfeature.sdk.*
+import dev.openfeature.kotlin.sdk.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob


### PR DESCRIPTION
### Description
This branch forks the upstream upgrade work from `bencehornak:upgrade-openfeature` in PR [#268](`https://github.com/DevCycleHQ/android-client-sdk/pull/268`) and addresses an additional compatibility item.

- Upstream changes upgrade OpenFeature to `dev.openfeature:kotlin-sdk:0.6.2` and migrate imports.
- This branch updates R8/ProGuard rules to match the new package namespace:
  - Replace `dev.openfeature.sdk.**` with `dev.openfeature.kotlin.sdk.**`
  - Add corresponding `-dontwarn` for the new package