### PR TITLE
fix: keep dependabot remediation compatible with minSdk 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ all around the world.
 
 ## Requirements
 
-This version of the DevCycle Android Client SDK supports a minimum Android API Version 23.
+This version of the DevCycle Android Client SDK supports a minimum Android API Version 23 (Android 6.0, released October 2015).
 
 ## Installation
 

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -95,10 +95,12 @@ ext {
     androidx_version = '1.15.0'
     retrofit_version = "2.11.0"
     swagger_annotations_version = '2.2.26'
-    jackson_version = "2.19.1"
+    jackson_version = "2.21.1"
+    // jackson-module-kotlin 2.21+ uses MethodHandle.invokeExact which requires minSdk 26.
+    // Keep at 2.19.1 until minSdk is raised to 26+.
     jackson_kotlin_version = "2.19.1"
     //noinspection DuplicatePlatformClasses
-    jackson_jparser_version = "2.19.1"
+    jackson_jparser_version = "2.21.1"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.10.2'
     kotlin_reflect_version = '2.1.20'
@@ -129,7 +131,9 @@ dependencies {
     }
     implementation("io.swagger.core.v3:swagger-annotations:$swagger_annotations_version")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${jackson_kotlin_version}")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin") {
+        version { strictly jackson_kotlin_version }
+    }
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jackson_jparser_version}") {
         exclude group:'org.json', module:'json'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,42 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.11.2.0"
+    }
+    // Force patched versions of vulnerable transitive dependencies in the build classpath
+    configurations.classpath {
+        resolutionStrategy {
+            force 'io.netty:netty-codec-http:4.1.129.Final'
+            force 'io.netty:netty-codec-http2:4.1.129.Final'
+            force 'io.netty:netty-codec:4.1.129.Final'
+            force 'io.netty:netty-handler:4.1.129.Final'
+            force 'io.netty:netty-common:4.1.129.Final'
+            force 'org.bitbucket.b_c:jose4j:0.9.6'
+            force 'org.jdom:jdom2:2.0.6.1'
+            force 'com.google.protobuf:protobuf-java:3.25.5'
+            force 'com.google.protobuf:protobuf-kotlin:3.25.5'
+            force 'org.apache.commons:commons-compress:1.26.0'
+        }
+    }
+}
+
+// Force patched versions of vulnerable transitive dependencies in all subproject configurations
+subprojects {
+    configurations.configureEach {
+        resolutionStrategy {
+            force 'io.netty:netty-codec-http:4.1.129.Final'
+            force 'io.netty:netty-codec-http2:4.1.129.Final'
+            force 'io.netty:netty-codec:4.1.129.Final'
+            force 'io.netty:netty-handler:4.1.129.Final'
+            force 'io.netty:netty-common:4.1.129.Final'
+            force 'org.bitbucket.b_c:jose4j:0.9.6'
+            force 'org.jdom:jdom2:2.0.6.1'
+            force 'com.google.protobuf:protobuf-java:3.25.5'
+            force 'com.google.protobuf:protobuf-kotlin:3.25.5'
+            force 'org.apache.commons:commons-compress:1.26.0'
+        }
     }
 }
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java-example/build.gradle
+++ b/java-example/build.gradle
@@ -43,7 +43,3 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation(project(":android-client-sdk"))
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '8.11.1'
-}

--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -50,7 +50,3 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation(project(":android-client-sdk"))
 }
-
-task wrapper(type: Wrapper){
-    gradleVersion = '8.11.1'
-}

--- a/openfeature-example/build.gradle
+++ b/openfeature-example/build.gradle
@@ -51,7 +51,3 @@ dependencies {
     implementation(project(":android-client-sdk"))
     implementation 'dev.openfeature:kotlin-sdk:0.6.2'
 }
-
-task wrapper(type: Wrapper){
-    gradleVersion = '7.4'
-}


### PR DESCRIPTION
## Summary
- keep the dependabot/security remediation from #285 without raising `minSdk`
- pin `jackson-module-kotlin` to `2.19.1` using a strict version so `jackson-bom` doesn't upgrade it to a build that requires API 26
- keep the remaining Jackson modules on `2.21.1` and retain the forced patched build-time transitive dependencies from the AGP upgrade

## This PR
The main blocker for staying on API 23 is `jackson-module-kotlin` `2.21+`, which uses `MethodHandle.invokeExact` and effectively requires `minSdk 26`.

I think it probably makes sense to keep `jackson-core` / `jackson-databind` / `jackson-datatype-json-org` on the patched versions, while holding only `jackson-module-kotlin` back to `2.19.1` until we intentionally raise the Android floor.

## Verification
- `./gradlew :android-client-sdk:dependencies --configuration releaseRuntimeClasspath`
- `./gradlew buildEnvironment`

`./gradlew test` requires a local Android SDK and couldn't run in this environment.

### Related Issues
- alternative to #285