### PR TITLE
feat: use cached config if avail on init with openfeature provider

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
@@ -689,7 +689,9 @@ class DevCycleClient private constructor(
                 if (isConfigError) {
                     dvcSharedPrefs.clearConfigForUser(userAtRefreshStart)
                     DevCycleLogger.w("Background refresh config error (${(error as DVCRequestException).statusCode}). Persisted cache cleared.")
-                    notifyConfigError(error)
+                    if (configUpdatedCallbacks.isNotEmpty()) {
+                        notifyConfigError(error)
+                    }
                 } else {
                     DevCycleLogger.w("Background refresh failed: ${error.message}. Keeping caches.")
                 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
@@ -77,19 +77,19 @@ class DevCycleClient private constructor(
     private var latestIdentifiedUser: PopulatedUser = user
 
     private val variableInstanceMap: MutableMap<String, MutableMap<Any, WeakReference<Variable<*>>>> = mutableMapOf()
+    private val configUpdatedCallbacks = java.util.concurrent.CopyOnWriteArrayList<DevCycleCallback<Map<String, BaseConfigVariable>>>()
 
     init {
-        useCachedConfigForUser(user)
+        val cacheHit = useCachedConfigForUser(user)
 
-        initializeJob = coroutineScope.async(coroutineContext) {
-            isExecuting.set(true)
-            try {
-                fetchConfig(user)
-                isInitialized.set(true)
-                withContext(Dispatchers.IO){
+        if (cacheHit) {
+            isInitialized.set(true)
+            initializeJob = CompletableDeferred(Unit)
+
+            coroutineScope.launch(coroutineContext) {
+                withContext(Dispatchers.IO) {
                     initEventSource()
-                    val application : Application = context.applicationContext as Application
-
+                    val application: Application = context.applicationContext as Application
                     val lifecycleCallbacks = DVCLifecycleCallbacks(
                         onPauseApplication,
                         onResumeApplication,
@@ -98,17 +98,38 @@ class DevCycleClient private constructor(
                     )
                     application.registerActivityLifecycleCallbacks(lifecycleCallbacks)
                 }
-
-            } catch (t: Throwable) {
-                DevCycleLogger.e(t, "DevCycle SDK Failed to Initialize!")
-                throw t
+                // Fetch fresh config in background (ADR 0009). SSE only fires on
+                // server-side changes, so an explicit fetch is needed to verify the cache.
+                performBackgroundRefresh()
             }
-        }
+        } else {
+            initializeJob = coroutineScope.async(coroutineContext) {
+                isExecuting.set(true)
+                try {
+                    fetchConfig(user)
+                    isInitialized.set(true)
+                    withContext(Dispatchers.IO) {
+                        initEventSource()
+                        val application: Application = context.applicationContext as Application
+                        val lifecycleCallbacks = DVCLifecycleCallbacks(
+                            onPauseApplication,
+                            onResumeApplication,
+                            config?.sse?.inactivityDelay?.toLong(),
+                            customLifecycleHandler
+                        )
+                        application.registerActivityLifecycleCallbacks(lifecycleCallbacks)
+                    }
+                } catch (t: Throwable) {
+                    DevCycleLogger.e(t, "DevCycle SDK Failed to Initialize!")
+                    throw t
+                }
+            }
 
-        initializeJob.invokeOnCompletion {
-            coroutineScope.launch(coroutineContext) {
-                handleQueuedConfigRequests()
-                isExecuting.set(false)
+            initializeJob.invokeOnCompletion {
+                coroutineScope.launch(coroutineContext) {
+                    handleQueuedConfigRequests()
+                    isExecuting.set(false)
+                }
             }
         }
     }
@@ -193,6 +214,8 @@ class DevCycleClient private constructor(
         }
     }
 
+    internal fun hasUsableCachedConfig(): Boolean = config != null && isConfigCached.get()
+
     /**
      * Updates or builds a new User and fetches the latest config for that User
      *
@@ -233,12 +256,21 @@ class DevCycleClient private constructor(
             override fun onError(error: Throwable) {
                 DevCycleLogger.d("Error fetching config for user_id %s: %s", updatedUser.userId, error.message)
 
+                if (error is DVCRequestException && (error.isAuthError || error.statusCode == 400)) {
+                    dvcSharedPrefs.clearConfigForUser(updatedUser)
+                    DevCycleLogger.w("Config error during identifyUser (${error.statusCode}). Persisted cache cleared.")
+                    latestIdentifiedUser = previousUser
+                    callback?.onError(error)
+                    return
+                }
+
                 // In the event that the config request fails (i.e. the device is offline)
                 // Fallback to using a Cached Configuration for the User if available
                 val hasCachedConfig = tryLoadCachedConfigForUser(updatedUser)
                 if (hasCachedConfig) {
                     // Successfully used cached config, return success
                     config?.variables?.let { callback?.onSuccess(it) }
+                    performBackgroundRefresh()
                 } else {
                     // No cached config available, restore previous state and return error
                     latestIdentifiedUser = previousUser
@@ -511,6 +543,10 @@ class DevCycleClient private constructor(
         isConfigCached.set(false)
         DevCycleLogger.d("A new config has been fetched for $user")
 
+        if (isInitialized.get()) {
+            notifyConfigUpdated(result.variables)
+        }
+
         this@DevCycleClient.user = user
 
         if (checkIfEdgeDBEnabled(result, enableEdgeDB)) {
@@ -587,14 +623,16 @@ class DevCycleClient private constructor(
         }
     }
 
-    private fun useCachedConfigForUser(user: PopulatedUser) {
+    private fun useCachedConfigForUser(user: PopulatedUser): Boolean {
         val cachedConfig = if (disableConfigCache) null else dvcSharedPrefs.getConfig(user)
         if (cachedConfig != null) {
             config = cachedConfig
             isConfigCached.set(true)
             DevCycleLogger.d("Loaded config from cache for user_id %s", user.userId)
             observable.configUpdated(config)
+            return true
         }
+        return false
     }
 
     private fun tryLoadCachedConfigForUser(user: PopulatedUser): Boolean {
@@ -609,6 +647,54 @@ class DevCycleClient private constructor(
         } else {
             return false
         }
+    }
+
+    internal fun onConfigUpdated(callback: DevCycleCallback<Map<String, BaseConfigVariable>>) {
+        configUpdatedCallbacks.add(callback)
+    }
+
+    private fun notifyConfigUpdated(variables: Map<String, BaseConfigVariable>?) {
+        variables?.let { vars ->
+            configUpdatedCallbacks.forEach { callback ->
+                try {
+                    callback.onSuccess(vars)
+                } catch (e: Exception) {
+                    DevCycleLogger.e(e, "Error in config updated callback")
+                }
+            }
+        }
+    }
+
+    private fun notifyConfigError(error: Throwable) {
+        configUpdatedCallbacks.forEach { callback ->
+            try {
+                callback.onError(error)
+            } catch (e: Exception) {
+                DevCycleLogger.e(e, "Error in config error callback")
+            }
+        }
+    }
+
+    private fun performBackgroundRefresh() {
+        val userAtRefreshStart = latestIdentifiedUser
+        refetchConfig(false, null, null, object : DevCycleCallback<Map<String, BaseConfigVariable>> {
+            override fun onSuccess(result: Map<String, BaseConfigVariable>) {
+                DevCycleLogger.d("Background refresh succeeded")
+            }
+
+            override fun onError(error: Throwable) {
+                val isConfigError = error is DVCRequestException &&
+                        (error.isAuthError || error.statusCode == 400)
+
+                if (isConfigError) {
+                    dvcSharedPrefs.clearConfigForUser(userAtRefreshStart)
+                    DevCycleLogger.w("Background refresh config error (${(error as DVCRequestException).statusCode}). Persisted cache cleared.")
+                    notifyConfigError(error)
+                } else {
+                    DevCycleLogger.w("Background refresh failed: ${error.message}. Keeping caches.")
+                }
+            }
+        })
     }
 
     class DevCycleClientBuilder {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
@@ -538,9 +538,9 @@ class DevCycleClient private constructor(
     ) {
         val result = request.getConfigJson(sdkKey, user, enableEdgeDB, sse, lastModified, etag)
         config = result
-        observable.configUpdated(config)
         dvcSharedPrefs.saveConfig(result, user)
         isConfigCached.set(false)
+        observable.configUpdated(config)
         DevCycleLogger.d("A new config has been fetched for $user")
 
         if (isInitialized.get()) {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/DevCycleClient.kt
@@ -372,6 +372,11 @@ class DevCycleClient private constructor(
         Variable.getAndValidateType(defaultValue)
         val variable = this.getCachedVariable(key, defaultValue)
 
+        val currentEval = variable.eval
+        if (isConfigCached.get() && currentEval != null) {
+            variable.eval = EvalReason.withCachedSource(currentEval)
+        }
+
         val tmpConfig = config
         if(!disableAutomaticEventLogging){
             val event: Event = Event.fromInternalEvent(

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/Request.kt
@@ -26,7 +26,7 @@ internal class Request constructor(sdkKey: String, apiBaseUrl: String, eventsBas
         if (response.isSuccessful) {
             return response.body() ?: throw Throwable("Unexpected result from API")
         } else {
-            val httpResponseCode = HttpResponseCode.byCode(response.code())
+            val statusCode = response.code()
             var errorResponse = ErrorResponse(listOf("Unknown Error"), null)
 
             response.errorBody()?.let { errorBody ->
@@ -35,13 +35,13 @@ internal class Request constructor(sdkKey: String, apiBaseUrl: String, eventsBas
                         errorBody.string(),
                         ErrorResponse::class.java
                     )
-                    throw DVCRequestException(httpResponseCode, errorResponse)
+                    throw DVCRequestException(statusCode, errorResponse)
                 } catch (e: IOException) {
                     errorResponse = ErrorResponse(listOf(e.message ?: ""), null)
-                    throw DVCRequestException(httpResponseCode, errorResponse)
+                    throw DVCRequestException(statusCode, errorResponse)
                 }
             }
-            throw DVCRequestException(httpResponseCode, errorResponse)
+            throw DVCRequestException(statusCode, errorResponse)
         }
     }
 

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/DVCRequestException.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/exception/DVCRequestException.kt
@@ -4,16 +4,17 @@ import com.devcycle.sdk.android.model.ErrorResponse
 import com.devcycle.sdk.android.model.HttpResponseCode
 
 class DVCRequestException(
-    private val httpResponseCode:HttpResponseCode,
-    private val errorResponse: ErrorResponse): Exception(errorResponse.message?.getOrNull(0)) {
+    val statusCode: Int,
+    private val errorResponse: ErrorResponse
+): Exception(errorResponse.message?.getOrNull(0)) {
 
-    fun getHttpResponseCode(): HttpResponseCode {
-        return httpResponseCode
-    }
+    private val httpResponseCode = HttpResponseCode.byCode(statusCode)
 
-    fun getErrorResponse(): ErrorResponse {
-        return errorResponse
-    }
+    fun getHttpResponseCode(): HttpResponseCode = httpResponseCode
 
-    val isRetryable get() = httpResponseCode.code >= 500
+    fun getErrorResponse(): ErrorResponse = errorResponse
+
+    val isRetryable get() = statusCode == 429 || statusCode >= 500
+
+    val isAuthError get() = statusCode == 401 || statusCode == 403
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EvalReason.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/EvalReason.kt
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.android.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -26,8 +27,19 @@ data class EvalReason(
     @get:Schema(required = false, description = "String that defines the target id for the evaluation")
     @JsonProperty("target_id")
     val targetId: String? = null,
+
+    /**
+     * Indicates the data source for this evaluation: "CACHED" when served from
+     * persistent cache, null when served from a live server response.
+     */
+    @get:Schema(required = false, description = "Data source indicator: CACHED or null (live)")
+    @JsonIgnore
+    val source: String? = null,
 ) {
     companion object {
         fun defaultReason(details: String) = EvalReason("DEFAULT", details)
+
+        fun withCachedSource(original: EvalReason) =
+            original.copy(source = "CACHED")
     }
 }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/HttpResponseCode.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/model/HttpResponseCode.kt
@@ -1,7 +1,14 @@
 package com.devcycle.sdk.android.model
 
 enum class HttpResponseCode(val code: Int) {
-    OK(200), ACCEPTED(201), BAD_REQUEST(400), UNAUTHORIZED(401), NOT_FOUND(404), SERVER_ERROR(500);
+    OK(200),
+    ACCEPTED(201),
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    TOO_MANY_REQUESTS(429),
+    SERVER_ERROR(500);
 
     companion object {
         fun byCode(code: Int): HttpResponseCode {

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -9,7 +9,11 @@ import com.devcycle.sdk.android.model.DevCycleUser
 import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.DevCycleLogger
 import dev.openfeature.kotlin.sdk.*
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONArray
 import org.json.JSONObject
@@ -23,6 +27,8 @@ class DevCycleProvider(
     override val hooks: List<Hook<*>> = emptyList(),
     override val metadata: ProviderMetadata = DevCycleProviderMetadata()
 ) : FeatureProvider {
+
+    private val _providerEvents = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 1)
 
     /**
      * The DevCycle client instance - created during initialization
@@ -56,10 +62,16 @@ class DevCycleProvider(
             }
         }
 
+        val reason = when {
+            variable.isDefaulted == true -> Reason.DEFAULT.toString()
+            variable.eval?.source == "CACHED" -> "CACHED"
+            else -> variable.eval?.reason ?: Reason.TARGETING_MATCH.toString()
+        }
+
         return ProviderEvaluation(
             value = value,
             variant = variable.key,
-            reason = variable.eval?.reason ?: if (variable.isDefaulted == true) Reason.DEFAULT.toString() else Reason.TARGETING_MATCH.toString(),
+            reason = reason,
             metadata = if (hasMetadata) metadataBuilder.build() else EvaluationMetadata.EMPTY
         )
     }
@@ -104,7 +116,26 @@ class DevCycleProvider(
 
             _devcycleClient = clientBuilder.build()
 
-            // Wait for DevCycle client to fully initialize
+            _devcycleClient!!.onConfigUpdated(object : DevCycleCallback<Map<String, BaseConfigVariable>> {
+                override fun onSuccess(result: Map<String, BaseConfigVariable>) {
+                    _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
+                    DevCycleLogger.d("Emitted PROVIDER_CONFIGURATION_CHANGED event")
+                }
+
+                override fun onError(t: Throwable) {
+                    DevCycleLogger.e("Config error: ${t.message}")
+                    _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderError(
+                        OpenFeatureError.GeneralError(t.message ?: "Config error")
+                    ))
+                }
+            })
+
+            if (_devcycleClient!!.hasUsableCachedConfig()) {
+                DevCycleLogger.d("DevCycle OpenFeature provider initialized from cache (PROVIDER_READY)")
+                return
+            }
+
+            // Cache miss: block until network fetch completes
             suspendCancellableCoroutine<Unit> { continuation ->
                 _devcycleClient!!.onInitialized(object : DevCycleCallback<String> {
                     override fun onSuccess(result: String) {
@@ -161,6 +192,8 @@ class DevCycleProvider(
             throw OpenFeatureError.GeneralError("Error setting context: ${e.message}")
         }
     }
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = _providerEvents.asSharedFlow()
 
     override fun shutdown() {
         _devcycleClient?.close()

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/util/DVCSharedPrefs.kt
@@ -188,6 +188,21 @@ internal class DVCSharedPrefs(context: Context, private val configCacheTTL: Long
 
 
     @Synchronized
+    fun clearConfigForUser(user: PopulatedUser) {
+        try {
+            val userKey = generateUserConfigKey(user.userId, user.isAnonymous)
+            val userExpiryDateKey = generateUserExpiryDateKey(user.userId, user.isAnonymous)
+            val editor = preferences.edit()
+            editor.remove(userKey)
+            editor.remove(userExpiryDateKey)
+            editor.apply()
+            DevCycleLogger.d("Cleared persisted config for user_id %s", user.userId)
+        } catch (e: Exception) {
+            DevCycleLogger.e(e, "Error clearing config for user: ${e.message}")
+        }
+    }
+
+    @Synchronized
     fun remove(key: String?) {
         try {
             val editor: SharedPreferences.Editor = preferences.edit()

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DevCycleClientTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/DevCycleClientTests.kt
@@ -2358,6 +2358,150 @@ class DevCycleClientTests {
     }
     
     @Test
+    fun `cache-first init resolves immediately when cache exists`() {
+        val config = generateConfig("cached-flag", "Cached value!", Variable.TypeEnum.STRING, targetingMatch)
+
+        // First response for background refresh
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(objectMapper.writeValueAsString(config)))
+
+        // Pre-populate the cache by using the editor stubs
+        val configJson = objectMapper.writeValueAsString(config)
+        `when`(sharedPreferences?.getString(ArgumentMatchers.eq("IDENTIFIED_CONFIG.nic_test"), ArgumentMatchers.isNull())).thenReturn(configJson)
+        `when`(sharedPreferences?.getLong(ArgumentMatchers.eq("IDENTIFIED_CONFIG.nic_test.EXPIRY_DATE"), ArgumentMatchers.eq(0L))).thenReturn(System.currentTimeMillis() + 86400000L)
+
+        val client = createClient(TEST_SDK_KEY, mockWebServer.url("/").toString())
+
+        var initCalledBack = false
+        val initLatch = CountDownLatch(1)
+
+        client.onInitialized(object : DevCycleCallback<String> {
+            override fun onSuccess(result: String) {
+                initCalledBack = true
+                initLatch.countDown()
+            }
+
+            override fun onError(t: Throwable) {
+                initLatch.countDown()
+            }
+        })
+
+        // onInitialized should resolve immediately on cache hit
+        Assertions.assertTrue(initLatch.await(3000, TimeUnit.MILLISECONDS), "onInitialized should resolve on cache hit")
+        Assertions.assertTrue(initCalledBack, "onInitialized should call success callback on cache hit")
+        client.close()
+    }
+
+    @Test
+    fun `identifyUser with auth error clears persisted cache`() {
+        val config = generateConfig("activate-flag", "Flag activated!", Variable.TypeEnum.STRING, targetingMatch)
+
+        val requestCount = AtomicInteger(0)
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                if (request.path == "/v1/events") {
+                    return MockResponse().setResponseCode(201).setBody("{\"message\": \"Success\"}")
+                } else if (request.path?.contains("/v1/mobileSDKConfig") == true) {
+                    val count = requestCount.incrementAndGet()
+                    return if (count == 1) {
+                        MockResponse().setResponseCode(200).setBody(objectMapper.writeValueAsString(config))
+                    } else {
+                        MockResponse().setResponseCode(401).setBody("{\"message\":[\"Unauthorized\"],\"statusCode\":401}")
+                    }
+                }
+                return MockResponse().setResponseCode(404)
+            }
+        }
+
+        val client = createClient(TEST_SDK_KEY, mockWebServer.url("/").toString())
+
+        val initLatch = CountDownLatch(1)
+        client.onInitialized(object : DevCycleCallback<String> {
+            override fun onSuccess(result: String) {
+                initLatch.countDown()
+            }
+            override fun onError(t: Throwable) {
+                initLatch.countDown()
+            }
+        })
+        initLatch.await(3000, TimeUnit.MILLISECONDS)
+
+        val identifyLatch = CountDownLatch(1)
+        var identifyError: Throwable? = null
+        val newUser = DevCycleUser.builder().withUserId("auth_error_user").build()
+        client.identifyUser(newUser, object : DevCycleCallback<Map<String, BaseConfigVariable>> {
+            override fun onSuccess(result: Map<String, BaseConfigVariable>) {
+                identifyLatch.countDown()
+            }
+            override fun onError(t: Throwable) {
+                identifyError = t
+                identifyLatch.countDown()
+            }
+        })
+
+        identifyLatch.await(3000, TimeUnit.MILLISECONDS)
+        Assertions.assertNotNull(identifyError, "identifyUser should return error on 401")
+
+        // Verify persisted cache was cleared for the new user
+        Mockito.verify(editor, Mockito.atLeastOnce())?.remove(ArgumentMatchers.contains("IDENTIFIED_CONFIG"))
+        client.close()
+    }
+
+    @Test
+    fun `onConfigUpdated callback fires on config change after init`() {
+        val config = generateConfig("activate-flag", "Flag activated!", Variable.TypeEnum.STRING, targetingMatch)
+        val updatedConfig = generateConfig("activate-flag", "Updated!", Variable.TypeEnum.STRING, targetingMatch)
+
+        val requestCount = AtomicInteger(0)
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                if (request.path == "/v1/events") {
+                    return MockResponse().setResponseCode(201).setBody("{\"message\": \"Success\"}")
+                } else if (request.path?.contains("/v1/mobileSDKConfig") == true) {
+                    val count = requestCount.incrementAndGet()
+                    return if (count == 1) {
+                        MockResponse().setResponseCode(200).setBody(objectMapper.writeValueAsString(config))
+                    } else {
+                        MockResponse().setResponseCode(200).setBody(objectMapper.writeValueAsString(updatedConfig))
+                    }
+                }
+                return MockResponse().setResponseCode(404)
+            }
+        }
+
+        val client = createClient(TEST_SDK_KEY, mockWebServer.url("/").toString())
+
+        var configUpdatedCalled = false
+        val updateLatch = CountDownLatch(1)
+        client.onConfigUpdated(object : DevCycleCallback<Map<String, BaseConfigVariable>> {
+            override fun onSuccess(result: Map<String, BaseConfigVariable>) {
+                configUpdatedCalled = true
+                updateLatch.countDown()
+            }
+            override fun onError(t: Throwable) {
+                updateLatch.countDown()
+            }
+        })
+
+        val initLatch = CountDownLatch(1)
+        client.onInitialized(object : DevCycleCallback<String> {
+            override fun onSuccess(result: String) {
+                // Trigger a config change via identifyUser with same user (property update)
+                val sameUser = DevCycleUser.builder().withUserId("nic_test").build()
+                client.identifyUser(sameUser)
+                initLatch.countDown()
+            }
+            override fun onError(t: Throwable) {
+                initLatch.countDown()
+            }
+        })
+
+        initLatch.await(3000, TimeUnit.MILLISECONDS)
+        updateLatch.await(3000, TimeUnit.MILLISECONDS)
+        Assertions.assertTrue(configUpdatedCalled, "onConfigUpdated should be called on post-init config change")
+        client.close()
+    }
+
+    @Test
     fun `tryLoadCachedConfigForUser returns false when no cached config exists`() {
         val client = createClient(TEST_SDK_KEY, mockWebServer.url("/").toString())
         

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/model/EvalReasonTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/model/EvalReasonTests.kt
@@ -1,0 +1,19 @@
+package com.devcycle.sdk.android.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class EvalReasonTests {
+
+    @Test
+    fun `withCachedSource preserves original reason and sets source to CACHED`() {
+        val original = EvalReason("TARGETING_MATCH", "User ID", "target-123")
+        val cached = EvalReason.withCachedSource(original)
+
+        assertEquals("TARGETING_MATCH", cached.reason)
+        assertEquals("User ID", cached.details)
+        assertEquals("target-123", cached.targetId)
+        assertEquals("CACHED", cached.source)
+    }
+
+}

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/openfeature/DevCycleProviderTest.kt
@@ -176,6 +176,34 @@ class DevCycleProviderTest {
     }
 
     @Test
+    fun `initialize returns immediately when cached config is available`() {
+        every { mockDevCycleClient.hasUsableCachedConfig() } returns true
+
+        assertDoesNotThrow {
+            runBlocking {
+                provider.initialize(ImmutableContext(targetingKey = "cached-user"))
+            }
+        }
+
+        // onInitialized should NOT have been called since we short-circuited
+        io.mockk.verify(exactly = 0) { mockDevCycleClient.onInitialized(any()) }
+    }
+
+    @Test
+    fun `initialize blocks on network when no cached config`() {
+        every { mockDevCycleClient.hasUsableCachedConfig() } returns false
+
+        assertDoesNotThrow {
+            runBlocking {
+                provider.initialize(ImmutableContext(targetingKey = "fresh-user"))
+            }
+        }
+
+        // onInitialized SHOULD have been called since there was no cache
+        io.mockk.verify(exactly = 1) { mockDevCycleClient.onInitialized(any()) }
+    }
+
+    @Test
     fun `createProviderEvaluation includes metadata when eval details are available`() {
         setupInitializedProvider()
 
@@ -265,6 +293,54 @@ class DevCycleProviderTest {
     fun `accessing devcycleClient returns devcycleClient when client is initialized`() {
         setupInitializedProvider()
         assertEquals(mockDevCycleClient, provider.devcycleClient)
+    }
+
+    @Test
+    fun `createProviderEvaluation maps CACHED source to CACHED reason for non-defaulted variable`() {
+        setupInitializedProvider()
+
+        val mockVariable = mockk<Variable<String>>(relaxed = true)
+        val mockEvalReason = mockk<EvalReason>(relaxed = true)
+
+        every { mockVariable.key } returns "test-variable"
+        every { mockVariable.value } returns "cached-value"
+        every { mockVariable.isDefaulted } returns false
+        every { mockVariable.eval } returns mockEvalReason
+        every { mockEvalReason.reason } returns "TARGETING_MATCH"
+        every { mockEvalReason.source } returns "CACHED"
+        every { mockEvalReason.details } returns null
+        every { mockEvalReason.targetId } returns null
+
+        every { mockDevCycleClient.variable("test-variable", "default") } returns mockVariable
+
+        val result = provider.getStringEvaluation("test-variable", "default", null)
+
+        assertEquals("cached-value", result.value)
+        assertEquals("CACHED", result.reason)
+    }
+
+    @Test
+    fun `createProviderEvaluation keeps DEFAULT reason for defaulted variable even when source is CACHED`() {
+        setupInitializedProvider()
+
+        val mockVariable = mockk<Variable<String>>(relaxed = true)
+        val mockEvalReason = mockk<EvalReason>(relaxed = true)
+
+        every { mockVariable.key } returns "missing-key"
+        every { mockVariable.value } returns "default"
+        every { mockVariable.isDefaulted } returns true
+        every { mockVariable.eval } returns mockEvalReason
+        every { mockEvalReason.reason } returns "DEFAULT"
+        every { mockEvalReason.source } returns "CACHED"
+        every { mockEvalReason.details } returns "User Not Targeted"
+        every { mockEvalReason.targetId } returns null
+
+        every { mockDevCycleClient.variable("missing-key", "default") } returns mockVariable
+
+        val result = provider.getStringEvaluation("missing-key", "default", null)
+
+        assertEquals("default", result.value)
+        assertEquals("DEFAULT", result.reason)
     }
 
     private fun setupInitializedProvider() {

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/util/DVCSharedPrefsTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/util/DVCSharedPrefsTests.kt
@@ -513,6 +513,28 @@ class DVCSharedPrefsTests {
         verify(mockEditor, never()).apply()
     }
     
+    @Test
+    fun `should clear config and expiry for a specific user`() {
+        val user = createPopulatedUser(testUserId, false)
+        
+        dvcSharedPrefs.clearConfigForUser(user)
+        
+        verify(mockEditor).remove(eq("IDENTIFIED_CONFIG.$testUserId"))
+        verify(mockEditor).remove(eq("IDENTIFIED_CONFIG.$testUserId.EXPIRY_DATE"))
+        verify(mockEditor).apply()
+    }
+    
+    @Test
+    fun `should clear config for anonymous user`() {
+        val user = createPopulatedUser(testAnonUserId, true)
+        
+        dvcSharedPrefs.clearConfigForUser(user)
+        
+        verify(mockEditor).remove(eq("ANONYMOUS_CONFIG.$testAnonUserId"))
+        verify(mockEditor).remove(eq("ANONYMOUS_CONFIG.$testAnonUserId.EXPIRY_DATE"))
+        verify(mockEditor).apply()
+    }
+    
     private fun createPopulatedUser(userId: String, isAnonymous: Boolean): PopulatedUser {
         return PopulatedUser(
             userId = userId,


### PR DESCRIPTION
  Implements https://github.com/open-feature/protocol/pull/64 — cache-first initialization for static-context       
  providers.                                                                                                        
                                                                                                                    
  feat: cache-first initialization                                                                                  
   
  - SDK initializes immediately from cached config when available, fetches fresh values in the background           
  - Cache miss path unchanged — blocks on network as before                                                       
  - Evaluations served from cache surface reason = "CACHED"                                                         
                                                                                                                    
  feat: OpenFeature provider events
                                                                                                                    
  - PROVIDER_READY emitted immediately on cache hit                                                               
  - PROVIDER_CONFIGURATION_CHANGED emitted when background refresh delivers fresh values
  - PROVIDER_ERROR emitted on auth/config errors (400/401/403) during background refresh                            
                                                                                                                    
  feat: cache management                                                                                            
                                                                                                                    
  - Persisted cache cleared on auth/config errors so next cold start fetches fresh                                  
  - User switch clears in-memory config immediately to prevent serving stale values for the wrong identity
                                                                                                                    
  fix: HTTP status code classification                                                                            
                                                                                                                    
  - 403 and other unmapped codes were incorrectly collapsed to 500 and treated as retryable — now classified        
  correctly