### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,12 @@ buildscript {
     // Force patched versions of vulnerable transitive dependencies in the build classpath
     configurations.classpath {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.1.132.Final'
-            force 'io.netty:netty-codec-http2:4.1.132.Final'
-            force 'io.netty:netty-codec:4.1.132.Final'
-            force 'io.netty:netty-handler:4.1.132.Final'
-            force 'io.netty:netty-common:4.1.132.Final'
+            force 'io.netty:netty-codec-http:4.1.133.Final'
+            force 'io.netty:netty-codec-http2:4.1.133.Final'
+            force 'io.netty:netty-codec:4.1.133.Final'
+            force 'io.netty:netty-handler:4.1.133.Final'
+            force 'io.netty:netty-handler-proxy:4.1.133.Final'
+            force 'io.netty:netty-common:4.1.133.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'
@@ -34,11 +35,12 @@ buildscript {
 subprojects {
     configurations.configureEach {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.1.132.Final'
-            force 'io.netty:netty-codec-http2:4.1.132.Final'
-            force 'io.netty:netty-codec:4.1.132.Final'
-            force 'io.netty:netty-handler:4.1.132.Final'
-            force 'io.netty:netty-common:4.1.132.Final'
+            force 'io.netty:netty-codec-http:4.1.133.Final'
+            force 'io.netty:netty-codec-http2:4.1.133.Final'
+            force 'io.netty:netty-codec:4.1.133.Final'
+            force 'io.netty:netty-handler:4.1.133.Final'
+            force 'io.netty:netty-handler-proxy:4.1.133.Final'
+            force 'io.netty:netty-common:4.1.133.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'


### PR DESCRIPTION
## Summary

- Resolved 9 open Dependabot security alerts by bumping all forced Netty transitive dependencies from 4.1.132.Final to 4.1.133.Final
- Added `netty-handler-proxy` to the force-resolution list (was missing, covered alert #26)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #33 | `io.netty:netty-codec-http2` | **high** | Forced to 4.1.133.Final |
| #32 | `io.netty:netty-codec-http` | **high** | Forced to 4.1.133.Final |
| #31 | `io.netty:netty-codec-http` | **medium** | Forced to 4.1.133.Final |
| #30 | `io.netty:netty-codec-http` | **high** | Forced to 4.1.133.Final |
| #29 | `io.netty:netty-codec` | **high** | Forced to 4.1.133.Final |
| #28 | `io.netty:netty-codec-http` | **medium** | Forced to 4.1.133.Final |
| #27 | `io.netty:netty-codec-http` | **medium** | Forced to 4.1.133.Final |
| #26 | `io.netty:netty-handler-proxy` | **low** | Added force at 4.1.133.Final |
| #25 | `io.netty:netty-codec-http` | **medium** | Forced to 4.1.133.Final |

All Netty artifacts are transitive dependencies pulled in via the build toolchain (AGP/Gradle). The existing `resolutionStrategy.force` approach in `build.gradle` is the correct mechanism for this Android project — the fix upgrades the pinned version across both the `buildscript` classpath block and the `subprojects` block.