### PR TITLE
fix: don't block the calling thread when queueing events

### DIFF
--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/api/EventQueue.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.sync.withLock
 import java.math.BigDecimal
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 internal class EventQueue constructor(
     private val request: Request,
@@ -27,12 +29,15 @@ internal class EventQueue constructor(
 
     private val scheduler = Scheduler(coroutineScope, flushInMs)
     private var scheduleJob: Job? = null
-    // mutex to control flushing events, ensuring only one operation at a time
+    // coroutine mutex to control flushing events, ensuring only one operation at a time;
+    // held across the suspending network publish, so it must remain a coroutine Mutex
     private val flushMutex = Mutex()
-    // mutex to gate modifications to the aggregateEventMap
-    private val aggregateMutex = Mutex()
-    // mutex to gate modifications to the eventQueue
-    private val queueMutex = Mutex()
+    // lock to gate modifications to the aggregateEventMap; the critical section is non-suspending
+    // in-memory work reached from the synchronous variable() API, so a thread lock is used
+    private val aggregateLock = ReentrantLock()
+    // lock to gate modifications to the eventQueue; non-suspending, reached from the synchronous
+    // track() API, so a thread lock is used
+    private val queueLock = ReentrantLock()
     // ensures flushEvents does not get called after the sdk is closed
     val isClosed = AtomicBoolean(false)
     private val flushAgain = AtomicBoolean(true)
@@ -46,11 +51,13 @@ internal class EventQueue constructor(
                 val eventsToFlush: MutableList<Event> = mutableListOf()
                 eventsToFlush.addAll(currentEventQueue)
 
-                queueMutex.withLock {
+                // queueLock/aggregateLock are thread locks; these blocks never suspend, so they
+                // acquire and release on the same thread, before the suspending publish below.
+                queueLock.withLock {
                     eventQueue.removeAll(currentEventQueue)
                 }
 
-                aggregateMutex.withLock {
+                aggregateLock.withLock {
                     eventsToFlush.addAll(eventsFromAggregateEventMap())
                     aggregateEventMap.clear()
                 }
@@ -136,12 +143,10 @@ internal class EventQueue constructor(
             DevCycleLogger.w("Attempting to queue event after closing DevCycle.")
             return
         }
-        runBlocking {
-            queueMutex.withLock {
-                eventQueue.add(event)
-                DevCycleLogger.i("Event queued successfully %s", event)
-                scheduleJob = scheduler.scheduleWithDelay { run() }
-            }
+        queueLock.withLock {
+            eventQueue.add(event)
+            DevCycleLogger.i("Event queued successfully %s", event)
+            scheduleJob = scheduler.scheduleWithDelay { run() }
         }
     }
 
@@ -155,30 +160,28 @@ internal class EventQueue constructor(
             DevCycleLogger.w("Attempting to queue aggregate event after closing DVC.")
             return
         }
-        runBlocking {
-            aggregateMutex.withLock {
-                if (event.target == null || event.target == "") {
-                    throw IllegalArgumentException("Target must be set")
-                }
-                if (event.type == "") {
-                    throw IllegalArgumentException("Type must be set")
-                }
-
-                var aggEventType = aggregateEventMap[event.type]
-
-                if (aggEventType == null) {
-                    aggEventType = aggregateEventMap.getOrPut(event.type) { HashMap<String, Event>() }
-                    aggEventType[event.target] = event
-                } else if (aggEventType.containsKey(event.target)) {
-                    aggEventType[event.target] = event.copy(
-                        value = aggEventType[event.target]?.value?.plus(BigDecimal.ONE)
-                    )
-                } else {
-                    aggEventType[event.target] = event
-                }
-
-                scheduleJob = scheduler.scheduleWithDelay { run() }
+        aggregateLock.withLock {
+            if (event.target == null || event.target == "") {
+                throw IllegalArgumentException("Target must be set")
             }
+            if (event.type == "") {
+                throw IllegalArgumentException("Type must be set")
+            }
+
+            var aggEventType = aggregateEventMap[event.type]
+
+            if (aggEventType == null) {
+                aggEventType = aggregateEventMap.getOrPut(event.type) { HashMap<String, Event>() }
+                aggEventType[event.target] = event
+            } else if (aggEventType.containsKey(event.target)) {
+                aggEventType[event.target] = event.copy(
+                    value = aggEventType[event.target]?.value?.plus(BigDecimal.ONE)
+                )
+            } else {
+                aggEventType[event.target] = event
+            }
+
+            scheduleJob = scheduler.scheduleWithDelay { run() }
         }
     }
 

--- a/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/EventQueueTests.kt
+++ b/android-client-sdk/src/test/java/com/devcycle/sdk/android/api/EventQueueTests.kt
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mockito
 import java.math.BigDecimal
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 
 class EventQueueTests {
@@ -82,4 +85,59 @@ class EventQueueTests {
         Assert.assertEquals(optInEval, evalEventMetadata)
         Assert.assertEquals(defaultEval, defaultEventMetadata)
     }
+
+    @Test
+    fun `queueAggregateEvent throws synchronously when target is missing`() {
+        val request = Request("some-key", "http://fake.com", "http://fake.com", mockContext)
+        val user = PopulatedUser("test")
+        val eventQueue = EventQueue(request, { user }, CoroutineScope(Dispatchers.Default), 60000)
+        val eval = EvalReason("OPT_IN", "Opt-In", "target")
+        val eventWithNoTarget =
+            Event.fromInternalEvent(Event.variableEvent(false, "", eval), user, null)
+
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            eventQueue.queueAggregateEvent(eventWithNoTarget)
+        }
+    }
+
+    @Test
+    fun `concurrent queueAggregateEvent produces correct aggregate counts`() {
+        val request = Request("some-key", "http://fake.com", "http://fake.com", mockContext)
+        val user = PopulatedUser("test")
+        val eventQueue = EventQueue(request, { user }, CoroutineScope(Dispatchers.Default), 60000)
+        val eval = EvalReason("OPT_IN", "Opt-In", "target")
+        val keys = listOf("key0", "key1", "key2", "key3")
+
+        val threads = 8
+        val callsPerThread = 5000
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                repeat(callsPerThread) { i ->
+                    val key = keys[i % keys.size]
+                    eventQueue.queueAggregateEvent(
+                        Event.fromInternalEvent(Event.variableEvent(false, key, eval), user, null)
+                    )
+                }
+                done.countDown()
+            }
+        }
+        start.countDown()
+        Assert.assertTrue("workers did not finish", done.await(30, TimeUnit.SECONDS))
+        pool.shutdown()
+
+        val expectedPerKey = (threads * callsPerThread) / keys.size
+        keys.forEach { key ->
+            val event = eventQueue.aggregateEventMap[Event.Companion.EventTypes.variableEvaluated]?.get(key)
+            Assert.assertEquals(
+                "lost updates for $key",
+                BigDecimal(expectedPerKey),
+                event?.value
+            )
+        }
+    }
+
 }


### PR DESCRIPTION
# PR: `fix: don't block the calling thread when queueing events`

Fixes #296.

## What

`EventQueue.queueAggregateEvent()` and `queueEvent()` wrapped their in-memory critical sections in
`runBlocking { Mutex.withLock { … } }`. This PR guards those sections with a `ReentrantLock` and
removes `runBlocking`, so queueing an event no longer blocks the calling thread.

## Why

`variable()` / `variableValue()` / `track()` are **synchronous** APIs, and `DevCycleClient._variable()`
is `@Synchronized`. Because `queueAggregateEvent()` does `runBlocking { aggregateMutex.withLock { … } }`,
calling `variable()` on the Android **main thread** parks the main thread inside `runBlocking` while
holding the `DevCycleClient` monitor. Under contention with the periodic event flush this wedges and
freezes the main thread → main-thread ANRs (see the issue for production stacks; we were seeing this
as a high-volume production ANR).

## The change (one file, `EventQueue.kt`)

The critical sections guarded by `aggregateMutex` and `queueMutex` are pure in-memory work on
`aggregateEventMap` / `eventQueue` with **no suspension points**, so they don't need a coroutine
`Mutex`:

- `aggregateMutex`, `queueMutex` → `java.util.concurrent.locks.ReentrantLock` (`aggregateLock`,
  `queueLock`), using `kotlin.concurrent.withLock`.
- `queueAggregateEvent()` / `queueEvent()`: `runBlocking { }` removed; the body runs synchronously
  under the lock.
- `flushEvents()` keeps **`flushMutex` as a coroutine `Mutex`** — it is held across the suspending
  `request.publishEvents(...)`. Its two inner drain blocks switch to the new `ReentrantLock`s; those
  blocks never suspend, so the lock is acquired and released on one thread before the publish (noted
  in a comment).

`@Synchronized` on `_variable()` is intentionally left as-is. It was the amplifier, not the cause;
with queueing now non-blocking the monitor is held only for microseconds. Keeping the change scoped
to `EventQueue` keeps it easy to review and low-risk.

- **Behavior unchanged.** Same map/list mutations, same `BigDecimal.ONE` aggregation increments,
  same `IllegalArgumentException` validation (still thrown synchronously), same
  `scheduler.scheduleWithDelay { run() }` scheduling and flush path.
- **No thread lock held across a suspension.** Every `aggregateLock`/`queueLock` block contains only
  non-suspending work (collection ops, the non-suspending `eventsFromAggregateEventMap()`, and
  `launch`, which returns a `Job` without suspending), and in `flushEvents()` they release before the
  `publishEvents(...)` suspension — so there is no resume-on-another-thread / unlock-from-wrong-thread
  hazard.
- **Deadlock-free.** No thread holds two inner locks at once — `flushEvents()` takes `queueLock` and
  `aggregateLock` in separate sequential blocks, producers take exactly one, and `flushMutex` is only
  ever outermost and is never acquired by the producers.

## Tests

Unit tests in `EventQueueTests` (deterministic, no timing assertions):

- `events are aggregated correctly` (existing) — aggregation counts unchanged.
- `queueAggregateEvent throws synchronously when target is missing` — validation equivalence.
- `concurrent queueAggregateEvent produces correct aggregate counts` — 8 threads × 5k calls produce
  exact aggregate counts (no lost updates), with a bounded latch await.

The existing `DevCycleClientTests` (real `MockWebServer` flush/event path) pass unchanged, covering
end-to-end flush equivalence. `./gradlew build testDebugUnitTest` is green (JDK 18).

## Verification of the ANR fix (on-device)

The wedge requires the real Android main `Looper`, so it does **not** reproduce in JVM/Robolectric
unit tests — it only manifests on a device/emulator (ART). We reproduced and verified it on-device
with a deterministic before/after: driving `variable()` on the real main `Looper` while background
threads + `identifyUser` churn keep the flush contending the event-queue mutex, the **unpatched** SDK
freezes the main thread within ~8s, and the **patched** SDK soaks for 90s with no stall. The runnable
reproduction is in the linked issue. (We intentionally do not commit that instrumented test here —
it's a ~90s connected test, not suited to CI.)


