### PR TITLE
chore: update Android SDK min version to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ all around the world.
 
 ## Requirements
 
-This version of the DevCycle Android Client SDK supports a minimum Android API Version 23 (Android 6.0, released October 2015).
+This version of the DevCycle Android Client SDK supports a minimum Android API Version 26 (Android 8.0, released August 2017).
 
 ## Installation
 

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -20,7 +20,7 @@ android {
     compileSdk 35
 
     defaultConfig {
-        minSdk 23
+        minSdk 26
         targetSdk 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -96,11 +96,6 @@ ext {
     retrofit_version = "2.11.0"
     swagger_annotations_version = '2.2.26'
     jackson_version = "2.21.1"
-    // jackson-module-kotlin 2.21+ uses MethodHandle.invokeExact which requires minSdk 26.
-    // Keep at 2.19.1 until minSdk is raised to 26+.
-    jackson_kotlin_version = "2.19.1"
-    //noinspection DuplicatePlatformClasses
-    jackson_jparser_version = "2.21.1"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.10.2'
     kotlin_reflect_version = '2.1.20'
@@ -131,10 +126,8 @@ dependencies {
     }
     implementation("io.swagger.core.v3:swagger-annotations:$swagger_annotations_version")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin") {
-        version { strictly jackson_kotlin_version }
-    }
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jackson_jparser_version}") {
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jackson_version}") {
         exclude group:'org.json', module:'json'
     }
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")

--- a/java-example/build.gradle
+++ b/java-example/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.devcycle.javaexample"
-        minSdk 23
+        minSdk 26
         targetSdk 35
         versionCode 1
         versionName "1.0"

--- a/kotlin-example/build.gradle
+++ b/kotlin-example/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.devcycle.example"
-        minSdk 23
+        minSdk 26
         targetSdk 35
         versionCode 1
         versionName "1.0"

--- a/openfeature-example/build.gradle
+++ b/openfeature-example/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.devcycle.openfeatureexample"
-        minSdk 23
+        minSdk 26
         targetSdk 35
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
this updates the version to match what min requirement for jackson, 
- updating `jackson_kotlin_version` to `2.21.1` 
- tested example apps with `customData`, `privateCustomData` and `TrackingEventDetails` having multiple different datatypes 