### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -95,7 +95,7 @@ ext {
     androidx_version = '1.15.0'
     retrofit_version = "2.11.0"
     swagger_annotations_version = '2.2.26'
-    jackson_version = "2.21.1"
+    jackson_version = "2.21.4"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.11.0'
     kotlin_reflect_version = '2.1.20'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ buildscript {
             force 'org.bouncycastle:bcprov-jdk18on:1.84'
             force 'org.bouncycastle:bcpkix-jdk18on:1.84'
             force 'org.apache.commons:commons-lang3:3.20.0'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
+            force 'com.fasterxml.jackson.core:jackson-core:2.21.4'
         }
     }
 }
@@ -49,6 +51,8 @@ subprojects {
             force 'org.bouncycastle:bcprov-jdk18on:1.84'
             force 'org.bouncycastle:bcpkix-jdk18on:1.84'
             force 'org.apache.commons:commons-lang3:3.20.0'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
+            force 'com.fasterxml.jackson.core:jackson-core:2.21.4'
         }
     }
 }


### PR DESCRIPTION
## Summary

- Resolved 6 open Dependabot security alerts by bumping jackson-databind and related modules from 2.21.1 to 2.21.4

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #42 | `com.fasterxml.jackson.core:jackson-databind` | **high** | Bumped to 2.21.4 via `jackson_version` |
| #43 | `com.fasterxml.jackson.core:jackson-databind` | **high** | Bumped to 2.21.4 via `jackson_version` |
| #41 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.21.4 via `jackson_version` |
| #44 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.21.4 via `jackson_version` |
| #46 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.21.4 via `jackson_version` |
| #47 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.21.4 via `jackson_version` |

Also added `jackson-databind` and `jackson-core` to the `resolutionStrategy` force blocks in the root `build.gradle` to ensure transitive references via Retrofit's converter also resolve to the patched version.