### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -95,7 +95,7 @@ ext {
     androidx_version = '1.15.0'
     retrofit_version = "2.11.0"
     swagger_annotations_version = '2.2.52'
-    jackson_version = "2.21.4"
+    jackson_version = "2.21.5"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.11.0'
     kotlin_reflect_version = '2.1.20'

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ buildscript {
             force 'org.bouncycastle:bcprov-jdk18on:1.84'
             force 'org.bouncycastle:bcpkix-jdk18on:1.84'
             force 'org.apache.commons:commons-lang3:3.20.0'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
-            force 'com.fasterxml.jackson.core:jackson-core:2.21.4'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.21.5'
+            force 'com.fasterxml.jackson.core:jackson-core:2.21.5'
         }
     }
 }
@@ -51,8 +51,8 @@ subprojects {
             force 'org.bouncycastle:bcprov-jdk18on:1.84'
             force 'org.bouncycastle:bcpkix-jdk18on:1.84'
             force 'org.apache.commons:commons-lang3:3.20.0'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
-            force 'com.fasterxml.jackson.core:jackson-core:2.21.4'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.21.5'
+            force 'com.fasterxml.jackson.core:jackson-core:2.21.5'
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bumped `com.fasterxml.jackson.core:jackson-databind` (and `jackson-core`) from 2.21.4 to 2.21.5 to resolve a medium-severity deserialization vulnerability (CVE-2026-54515, alert #45)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #45 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.21.5 via `jackson_version` variable and forced resolution |

## Changes

- `android-client-sdk/build.gradle`: Updated `jackson_version` from 2.21.4 to 2.21.5
- `build.gradle`: Updated forced resolution versions for `jackson-databind` and `jackson-core` (classpath and subprojects) from 2.21.4 to 2.21.5

Build verified with `./gradlew assembleRelease` — BUILD SUCCESSFUL.