### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ buildscript {
     // Force patched versions of vulnerable transitive dependencies in the build classpath
     configurations.classpath {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.2.15.Final'
-            force 'io.netty:netty-codec-http2:4.2.15.Final'
-            force 'io.netty:netty-codec:4.2.15.Final'
-            force 'io.netty:netty-handler:4.2.15.Final'
-            force 'io.netty:netty-handler-proxy:4.2.15.Final'
-            force 'io.netty:netty-common:4.2.15.Final'
+            force 'io.netty:netty-codec-http:4.2.16.Final'
+            force 'io.netty:netty-codec-http2:4.2.16.Final'
+            force 'io.netty:netty-codec:4.2.16.Final'
+            force 'io.netty:netty-handler:4.2.16.Final'
+            force 'io.netty:netty-handler-proxy:4.2.16.Final'
+            force 'io.netty:netty-common:4.2.16.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'
@@ -37,12 +37,12 @@ buildscript {
 subprojects {
     configurations.configureEach {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.2.15.Final'
-            force 'io.netty:netty-codec-http2:4.2.15.Final'
-            force 'io.netty:netty-codec:4.2.15.Final'
-            force 'io.netty:netty-handler:4.2.15.Final'
-            force 'io.netty:netty-handler-proxy:4.2.15.Final'
-            force 'io.netty:netty-common:4.2.15.Final'
+            force 'io.netty:netty-codec-http:4.2.16.Final'
+            force 'io.netty:netty-codec-http2:4.2.16.Final'
+            force 'io.netty:netty-codec:4.2.16.Final'
+            force 'io.netty:netty-handler:4.2.16.Final'
+            force 'io.netty:netty-handler-proxy:4.2.16.Final'
+            force 'io.netty:netty-common:4.2.16.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'


### PR DESCRIPTION
## Summary

- Resolved 9 open Dependabot security alerts by bumping forced Netty transitive dependency versions from `4.2.15.Final` to `4.2.16.Final` in the root `build.gradle` resolution strategy (buildscript classpath and subprojects configurations)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #56 | `io.netty:netty-codec-http` | **medium** | Forced to 4.2.16.Final |
| #55 | `io.netty:netty-codec-compression` | **high** | Forced to 4.2.16.Final |
| #54 | `io.netty:netty-codec-http2` | **medium** | Forced to 4.2.16.Final |
| #53 | `io.netty:netty-codec-http` | **medium** | Forced to 4.2.16.Final |
| #52 | `io.netty:netty-codec-http` | **medium** | Forced to 4.2.16.Final |
| #51 | `io.netty:netty-codec-http` | **medium** | Forced to 4.2.16.Final |
| #50 | `io.netty:netty-codec-http` | **high** | Forced to 4.2.16.Final |
| #49 | `io.netty:netty-codec-http` | **high** | Forced to 4.2.16.Final |
| #48 | `io.netty:netty-codec-http` | **high** | Forced to 4.2.16.Final |

Netty is pulled in transitively via the buildscript classpath (through `grpc-netty`, used by a build plugin), not as a runtime dependency of the SDK itself. Verified via `./gradlew buildEnvironment` that all Netty artifacts now resolve to `4.2.16.Final`.

## Test plan

- [x] `./gradlew build` succeeds
- [x] `./gradlew buildEnvironment` confirms all `io.netty:*` artifacts resolve to `4.2.16.Final`
- [x] `./gradlew testDebugUnitTest` passes (167/167); one intermittent timing-based test (`DevCycleClientTests > variable calls back when variable value changes`, uses `CountDownLatch.await`) failed once and passed on retry — confirmed pre-existing flake unrelated to this change