### PR TITLE
chore(deps): bump dev.openfeature:kotlin-sdk to 0.8.0

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     implementation("androidx.core:core-ktx:$androidx_version")
 
     // OpenFeature Kotlin SDK
-    implementation("dev.openfeature:kotlin-sdk:0.6.2")
+    implementation("dev.openfeature:kotlin-sdk:0.8.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_version")

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -10,6 +10,7 @@ import com.devcycle.sdk.android.model.Variable
 import com.devcycle.sdk.android.util.DevCycleLogger
 import dev.openfeature.kotlin.sdk.*
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -141,11 +142,14 @@ class DevCycleProvider(
                 // delivers a new config.
                 _devcycleClient!!.onConfigUpdated(object : DevCycleCallback<Map<String, BaseConfigVariable>> {
                     override fun onSuccess(result: Map<String, BaseConfigVariable>) {
-                        _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
+                        _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
                     }
                     override fun onError(t: Throwable) {
                         _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderError(
-                            OpenFeatureError.GeneralError(t.message ?: "Config error")
+                            eventDetails = OpenFeatureProviderEvents.EventDetails(
+                                message = t.message ?: "Config error",
+                                errorCode = ErrorCode.GENERAL
+                            )
                         ))
                     }
                 })
@@ -160,7 +164,7 @@ class DevCycleProvider(
                             if (continuation.isActive) continuation.resume(Unit)
                         } else {
                             // Cache hit: continuation already resolved; surface network result as event.
-                            _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
+                            _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
                         }
                     }
                     override fun onError(t: Throwable) {
@@ -174,7 +178,10 @@ class DevCycleProvider(
                         } else {
                             // Cache hit: network error is non-fatal; always emit — continuation is already resolved.
                             _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderError(
-                                OpenFeatureError.GeneralError("Background refresh failed: ${t.message}")
+                                eventDetails = OpenFeatureProviderEvents.EventDetails(
+                                    message = "Background refresh failed: ${t.message}",
+                                    errorCode = ErrorCode.GENERAL
+                                )
                             ))
                         }
                     }

--- a/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
+++ b/android-client-sdk/src/main/java/com/devcycle/sdk/android/openfeature/DevCycleProvider.kt
@@ -179,7 +179,7 @@ class DevCycleProvider(
                             // Cache hit: network error is non-fatal; always emit — continuation is already resolved.
                             _providerEvents.tryEmit(OpenFeatureProviderEvents.ProviderError(
                                 eventDetails = OpenFeatureProviderEvents.EventDetails(
-                                    message = "Background refresh failed: ${t.message}",
+                                    message = "Background refresh failed: ${t.message ?: "Unknown error"}",
                                     errorCode = ErrorCode.GENERAL
                                 )
                             ))
@@ -342,4 +342,4 @@ class DevCycleProvider(
         }
     }
 
-} 
+}

--- a/openfeature-example/build.gradle
+++ b/openfeature-example/build.gradle
@@ -49,5 +49,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation(project(":android-client-sdk"))
-    implementation 'dev.openfeature:kotlin-sdk:0.6.2'
+    implementation 'dev.openfeature:kotlin-sdk:0.8.0'
 }


### PR DESCRIPTION
## Summary
- Bumps `dev.openfeature:kotlin-sdk` from 0.6.2 to 0.8.0 in the SDK and the OpenFeature example
- Adapts `DevCycleProvider.kt` to the breaking `OpenFeatureProviderEvents` change in 0.7.0
- `assembleDebug` passes for the SDK and all three example apps; 167 unit tests pass

## Implementation
0.7.0 turned `OpenFeatureProviderEvents` from a `sealed interface` with `object` variants into a `sealed class` of data classes carrying `eventDetails`, and `ProviderError`'s first positional parameter is now `eventDetails` rather than the now-deprecated `error`. Four call sites in `DevCycleProvider.kt`:

- `ProviderConfigurationChanged` to `ProviderConfigurationChanged()` (2 sites)
- Both `ProviderError(OpenFeatureError.GeneralError(...))` calls now pass `eventDetails = EventDetails(message, errorCode = ErrorCode.GENERAL)`. `ErrorCode.GENERAL` maps back through `toOpenFeatureStatusError()` to a non-fatal `OpenFeatureStatus.Error`, so the previous semantics hold.

`FeatureProvider` is unchanged between the two tags and `HookContext`'s new `hookData` param has a default, so nothing else needed touching.

### Notes
Since 0.7.1 `setProvider` calls `shutdown()` on the previous provider, so `DevCycleProvider.shutdown()` now closes the DevCycle client on provider swaps where it previously did not. Correct, but currently untested.
