### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.20-RC2'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.11.2.0"
     }
     // Force patched versions of vulnerable transitive dependencies in the build classpath


### PR DESCRIPTION
## Summary

- Bumped `org.jetbrains.kotlin:kotlin-gradle-plugin` from `2.1.20` to `2.4.20-RC2` to resolve a medium-severity unsafe deserialization vulnerability in the Kotlin build cache (alert #57).

## Notes

- No stable release fixes this yet; the first patched version listed by the advisory is a pre-release (`2.4.20-Beta1`). `2.4.20-RC2` is the newest available pre-release at time of writing and was verified to build and test cleanly.
- Verified with `./gradlew clean build` and `./gradlew testDebugUnitTest` locally (all green; one unrelated pre-existing test-order flake in `testMinifiedUnitTest` reproduces on both the old and new plugin version and passes on rerun).

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #57 | `org.jetbrains.kotlin:kotlin-gradle-plugin` | **medium** | Bumped to `2.4.20-RC2` |