### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -98,7 +98,7 @@ ext {
     jackson_version = "2.21.5"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.11.0'
-    kotlin_reflect_version = '2.4.20'
+    kotlin_reflect_version = '2.1.20'
 
     junit_version = "5.13.3"
     mockito_core_version = '5.19.0'
@@ -107,7 +107,7 @@ ext {
     hamcrest_version = "3.0"
     okhttp_version = "4.12.0"
     okhttp_eventsource_version = "4.3.0"
-    kotlin_version = '2.4.20'
+    kotlin_version = '2.1.20'
 
     android_core_version = "2.2.0"
     androidx_junit_version = "1.2.1"

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -98,7 +98,7 @@ ext {
     jackson_version = "2.21.5"
     gson_mapper_version = "2.8.6"
     coroutines_version = '1.11.0'
-    kotlin_reflect_version = '2.1.20'
+    kotlin_reflect_version = '2.4.20'
 
     junit_version = "5.13.3"
     mockito_core_version = '5.19.0'
@@ -107,7 +107,7 @@ ext {
     hamcrest_version = "3.0"
     okhttp_version = "4.12.0"
     okhttp_eventsource_version = "4.3.0"
-    kotlin_version = '2.1.20'
+    kotlin_version = '2.4.20'
 
     android_core_version = "2.2.0"
     androidx_junit_version = "1.2.1"

--- a/android-client-sdk/build.gradle
+++ b/android-client-sdk/build.gradle
@@ -107,7 +107,6 @@ ext {
     hamcrest_version = "3.0"
     okhttp_version = "4.12.0"
     okhttp_eventsource_version = "4.3.0"
-    kotlin_version = '2.1.20'
 
     android_core_version = "2.2.0"
     androidx_junit_version = "1.2.1"

--- a/build.gradle
+++ b/build.gradle
@@ -7,18 +7,18 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.20'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.11.2.0"
     }
     // Force patched versions of vulnerable transitive dependencies in the build classpath
     configurations.classpath {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.2.16.Final'
-            force 'io.netty:netty-codec-http2:4.2.16.Final'
-            force 'io.netty:netty-codec:4.2.16.Final'
-            force 'io.netty:netty-handler:4.2.16.Final'
-            force 'io.netty:netty-handler-proxy:4.2.16.Final'
-            force 'io.netty:netty-common:4.2.16.Final'
+            force 'io.netty:netty-codec-http:4.2.17.Final'
+            force 'io.netty:netty-codec-http2:4.2.17.Final'
+            force 'io.netty:netty-codec:4.2.17.Final'
+            force 'io.netty:netty-handler:4.2.17.Final'
+            force 'io.netty:netty-handler-proxy:4.2.17.Final'
+            force 'io.netty:netty-common:4.2.17.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'
@@ -37,12 +37,12 @@ buildscript {
 subprojects {
     configurations.configureEach {
         resolutionStrategy {
-            force 'io.netty:netty-codec-http:4.2.16.Final'
-            force 'io.netty:netty-codec-http2:4.2.16.Final'
-            force 'io.netty:netty-codec:4.2.16.Final'
-            force 'io.netty:netty-handler:4.2.16.Final'
-            force 'io.netty:netty-handler-proxy:4.2.16.Final'
-            force 'io.netty:netty-common:4.2.16.Final'
+            force 'io.netty:netty-codec-http:4.2.17.Final'
+            force 'io.netty:netty-codec-http2:4.2.17.Final'
+            force 'io.netty:netty-codec:4.2.17.Final'
+            force 'io.netty:netty-handler:4.2.17.Final'
+            force 'io.netty:netty-handler-proxy:4.2.17.Final'
+            force 'io.netty:netty-common:4.2.17.Final'
             force 'org.bitbucket.b_c:jose4j:0.9.6'
             force 'org.jdom:jdom2:2.0.6.1'
             force 'com.google.protobuf:protobuf-java:3.25.5'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.20'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.11.2.0"
     }
     // Force patched versions of vulnerable transitive dependencies in the build classpath


### PR DESCRIPTION
## Summary

- Bumped `io.netty:netty-codec-http` (and related forced Netty modules) from 4.2.16.Final to 4.2.17.Final to resolve a moderate cache poisoning / information disclosure vulnerability via CORS Vary header overwrite

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #58 | `io.netty:netty-codec-http` | **medium** | Bumped forced version to 4.2.17.Final |

## Unresolvable / Deferred

| Alert | Package | Severity | Reason |
|-------|---------|----------|--------|
| #57 | `org.jetbrains.kotlin:kotlin-gradle-plugin` | **medium** | The patched version (2.4.20-Beta1 minimum, 2.4.20 for a stable release) is incompatible with this repo's current toolchain: AGP 8.13.2's bundled R8/Lint fails to parse Kotlin 2.4.20's metadata format (`ExceptionInInitializerError` in `AndroidLintWorkAction`, confirmed reproducible in CI), and GitHub's hosted CodeQL Kotlin extractor explicitly rejects it ("Kotlin version 2.4.20 is too recent"). AGP 8.13.2 is the latest 8.x release; a fix requires bumping AGP to 9.x, which in turn requires Gradle 9.6.0 — a much larger, breaking upgrade spanning all four Gradle modules in this repo. That is out of scope for a routine dependabot-alerts PR and is recommended as a dedicated follow-up.

## Notes

- Verified with `./gradlew :android-client-sdk:testDebugUnitTest` and `./gradlew :android-client-sdk:build` — the SDK module builds and unit tests pass with the Netty bump alone.